### PR TITLE
Improve consistency of bulk speed test

### DIFF
--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -216,7 +216,9 @@ void BulkSpeedTest ( pfHash hash, uint32_t seed )
   printf("Bulk speed test - %d-byte keys\n",blocksize);
   double sumbpc = 0.0;
 
-  for(int align = 0; align < 8; align++)
+  volatile double warmup_cycles = SpeedTest(hash,seed,trials,blocksize,0);
+
+  for(int align = 7; align >= 0; align--)
   {
     double cycles = SpeedTest(hash,seed,trials,blocksize,align);
     


### PR DESCRIPTION
The bulk portion of the speed test was producing noticeably inconsistent results across multiple runs of SMhaser, on the order over several hundred MB/s. To fix this, I:
 * Reversed the order in which the test-with-given alignment loop runs, descending to 0.
 * Introduced a short one run warm-up.

With these changes, the results across runs show much tighter clustering consistent with expectations.