### PR TITLE
Using llvm/clang on OS X instead of non-native gcc/g++

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ rm -rf build
 mkdir build
 cd build
 case `uname -s` in
-Darwin) CXX=g++-mp-5 CC=gcc-mp-5 cmake .. ;;
+Darwin) CXX=clang++ CC=clang cmake .. ;;
 *)      CXX=g++-5.0  CC=gcc-5.0 cmake ..   ;;
 esac
 make


### PR DESCRIPTION
Clang now ships with OpenMP support OOB as of LLVM 3.1, so there
is no need to install a 3rd party compiler any longer.