### PR TITLE
Serialize invocations of hash function during benchmarking

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -262,7 +262,7 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
     {
       sum += TinySpeedTest(hashfunc<hashtype>(info->hash),sizeof(hashtype),i,info->verification,true);
     }
-    sum = sum / 32.0;
+    sum = sum / 31.0;
     printf("Average                                    %6.3f cycles/hash\n",sum);
     printf("\n");
     fflush(NULL);


### PR DESCRIPTION
The results of short inputs benchmark don't make any sense. For example, FNV1a of 16-byte input should take at least 3 (latency of IMUL)*16=48 cycles, but according to results, it takes just 26 cycles, which is impossible. And FNV1a of 19-byte keys are faster than FNV1a of 2-byte keys!

The benchmarking of short inputs is broken in two ways:

1. 20 cycles overhead is way too large. Some hash functions are faster than 
donothing() which is absurd. For very small inputs, benchmark mostly measures 
overhead instead of measuring hash function performance.
2. Unlike RDTSCP, RDTSC can be reordered. To make things worse, there is no 
dependency chain between executions of hash function, so they can be executed 
in parrallel by an out-of-order CPU. So in fact the benchmark executes many 
hash functions in parallel hiding their real latency + benchmarks boilerplate
 that wasn't supposed to be benchmarked.

See also this article about timing: http://www.intel.com/content/dam/www/public/us/en/documents/white-papers/ia-32-ia-64-benchmark-code-execution-paper.pdf

I'm not sure about the most correct way to solve the problem. However, approach in this PR seems to be mostly work, as imperfect as it is. For example, new FNV-1a results on Haswell: 

    Small key speed test -    1-byte keys -    15.10 cycles/hash
    Small key speed test -    2-byte keys -    18.56 cycles/hash
    Small key speed test -    3-byte keys -    22.08 cycles/hash
    Small key speed test -    4-byte keys -    26.06 cycles/hash
    Small key speed test -    5-byte keys -    30.15 cycles/hash
    Small key speed test -    6-byte keys -    33.00 cycles/hash
    Small key speed test -    7-byte keys -    36.95 cycles/hash
    Small key speed test -    8-byte keys -    40.83 cycles/hash
    Small key speed test -    9-byte keys -    44.02 cycles/hash
    Small key speed test -   10-byte keys -    47.63 cycles/hash

This looks about right, every additional byte adds 3-4 cycles to execution time -- and this reflects the FNV-1a algorithm that just serially multiplies every byte and xors it into the result. Overhead is still high, and probably should be subtracted in some way.