### PR TITLE
Small One-At-A-Time functions that passes SMHasher

### DIFF
--- a/Hashes.h
+++ b/Hashes.h
@@ -67,6 +67,8 @@ void sdbm                  ( const void * key, int len, uint32_t seed, void * ou
 void x17_test              ( const void * key, int len, uint32_t seed, void * out );
 void JenkinsOOAT           ( const void * key, int len, uint32_t seed, void * out );
 void JenkinsOOAT_perl      ( const void * key, int len, uint32_t seed, void * out );
+void GoodOAAT              ( const void * key, int len, uint32_t seed, void * out );
+void MicroOAAT             ( const void * key, int len, uint32_t seed, void * out );
 void SuperFastHash         ( const void * key, int len, uint32_t seed, void * out );
 void lookup3_test          ( const void * key, int len, uint32_t seed, void * out );
 void MurmurOAAT_test       ( const void * key, int len, uint32_t seed, void * out );

--- a/main.cpp
+++ b/main.cpp
@@ -116,6 +116,8 @@ HashInfo g_hashes[] =
   { x17_test,             32, 0x8128E14C, "x17",         "x17" },
   { JenkinsOOAT,          32, 0x83E133DA, "JenkinsOOAT", "Bob Jenkins' OOAT as in perl 5.18" },
   { JenkinsOOAT_perl,     32, 0xEE05869B, "JenkinsOOAT_perl", "Bob Jenkins' OOAT as in old perl5" },
+  { GoodOAAT,             32, 0x7B14EEE5, "GoodOAAT", "Small non-multiplicative OAAT that passes whole SMHasher (by funny-falcon)" },
+  { MicroOAAT,            32, 0x16F1BA97, "MicroOAAT", "Small non-multiplicative OAAT that passes all collision checks (by funny-falcon)" },
   { lookup3_test,         32, 0x3D83917A, "lookup3",     "Bob Jenkins' lookup3" },
   { SuperFastHash,        32, 0x980ACD1D, "superfast",   "Paul Hsieh's SuperFastHash" },
   { MurmurOAAT_test,      32, 0x5363BD98, "MurmurOAAT",  "Murmur one-at-a-time" },


### PR DESCRIPTION
GoodOAAT passes whole SMHasher and has bulk performance greater
than FNV1a (on modern x86).
It could be shortened if avalanche is not an issue (ie if it is
used for hash-tables with prime numbers) in a maner of MicroOAAT.

MicroOAAT - smallest function that passes all collision checks from
SMHasher. It has simpler loop than GoodOAAT, but unfortunately
Clang doesn't produce rotl instruction when `(x>>n|x<<(32-n))` happens
after multiplication, so it is slower than FNV1a with Clang.