### PR TITLE
Expand test limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 libSMHasherSupport.a
 /TAGS
 
+SMHasher
+
 README.speed
 YoshimitsuTRIAD/
 Yoshimura/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ fsbench-density/
 *.bak
 prof.h
 zlib/
+
+# Apple artefact
+.DS_Store

--- a/CityTest.cpp
+++ b/CityTest.cpp
@@ -11,6 +11,11 @@ void CityHash64_test ( const void * key, int len, uint32_t seed, void * out )
   *(uint64*)out = CityHash64WithSeed((const char *)key,len,seed);
 }
 
+void CityHash64noSeed_test ( const void * key, int len, uint32_t seed, void * out )
+{
+  *(uint64*)out = CityHash64((const char *)key,len); (void)seed;
+}
+
 #if defined(__SSE4_2__) && defined(__x86_64__)
 void CityHash128_test ( const void * key, int len, uint32_t seed, void * out )
 {

--- a/FarmTest.cc
+++ b/FarmTest.cc
@@ -11,6 +11,10 @@ void FarmHash64_test ( const void * key, int len, uint32_t seed, void * out ) {
   using namespace NAMESPACE_FOR_HASH_FUNCTIONS;
   *(uint64_t*)out = Hash64WithSeed((const char *)key,(size_t)len,(uint64_t)seed);
 }
+void FarmHash64noSeed_test ( const void * key, int len, uint32_t seed, void * out ) {
+  using namespace NAMESPACE_FOR_HASH_FUNCTIONS;
+  *(uint64_t*)out = Hash64((const char *)key,(size_t)len); (void)seed;
+}
 void FarmHash128_test ( const void * key, int len, uint32_t seed, void * out ) {
   using namespace NAMESPACE_FOR_HASH_FUNCTIONS;
   uint128_t s((uint64_t)seed, (uint64_t)0UL);

--- a/Hashes.h
+++ b/Hashes.h
@@ -160,7 +160,7 @@ inline void xxHash64_test( const void * key, int len, uint32_t seed, void * out 
 
 inline void xxh3_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
-  *(uint64_t*)out = (uint64_t) XXH3_64b(key, (size_t) len);
+  *(uint64_t*)out = (uint64_t) XXH3_64b_withSeed(key, (size_t) len, seed);
 }
 
 inline void xxh3low_test( const void * key, int len, uint32_t seed, void * out ) {

--- a/Hashes.h
+++ b/Hashes.h
@@ -76,15 +76,26 @@ void MurmurOAAT_test       ( const void * key, int len, uint32_t seed, void * ou
 void Crap8_test            ( const void * key, int len, uint32_t seed, void * out );
 
 void CityHash32_test       ( const void * key, int len, uint32_t seed, void * out );
-void CityHash64_test       ( const void * key, int len, uint32_t seed, void * out );
 void CityHash64noSeed_test ( const void * key, int len, uint32_t seed, void * out );
+void CityHash64_test       ( const void * key, int len, uint32_t seed, void * out );
+inline void CityHash64_low_test ( const void * key, int len, uint32_t seed, void * out ) {
+  uint64_t result;
+  CityHash64_test(key, len, seed, &result);
+  *(uint32_t*)out = (uint32_t)result;
+}
+inline void CityHash64_high_test ( const void * key, int len, uint32_t seed, void * out ) {
+  uint64_t result;
+  CityHash64_test(key, len, seed, &result);
+  *(uint32_t*)out = (uint32_t)(result>>32);
+}
 void CityHash128_test      ( const void * key, int len, uint32_t seed, void * out );
 void FarmHash32_test       ( const void * key, int len, uint32_t seed, void * out );
 void FarmHash64_test       ( const void * key, int len, uint32_t seed, void * out );
+void FarmHash64noSeed_test ( const void * key, int len, uint32_t seed, void * out );
 void FarmHash128_test      ( const void * key, int len, uint32_t seed, void * out );
-void farmhash32_c_test       ( const void * key, int len, uint32_t seed, void * out );
-void farmhash64_c_test       ( const void * key, int len, uint32_t seed, void * out );
-void farmhash128_c_test      ( const void * key, int len, uint32_t seed, void * out );
+void farmhash32_c_test     ( const void * key, int len, uint32_t seed, void * out );
+void farmhash64_c_test     ( const void * key, int len, uint32_t seed, void * out );
+void farmhash128_c_test    ( const void * key, int len, uint32_t seed, void * out );
 
 void SpookyHash32_test     ( const void * key, int len, uint32_t seed, void * out );
 void SpookyHash64_test     ( const void * key, int len, uint32_t seed, void * out );

--- a/Hashes.h
+++ b/Hashes.h
@@ -173,6 +173,21 @@ inline void xxh3high_test( const void * key, int len, uint32_t seed, void * out 
   *(uint32_t*)out = (uint32_t) (XXH3_64b(key, (size_t) len) >> 32);
 }
 
+inline void xxh128_test( const void * key, int len, uint32_t seed, void * out ) {
+  (void)seed;
+  *(XXH128_hash_t*)out = XXH128(key, (size_t) len, seed);
+}
+
+inline void xxh128low_test( const void * key, int len, uint32_t seed, void * out ) {
+  (void)seed;
+  *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).ll1);
+}
+
+inline void xxh128high_test( const void * key, int len, uint32_t seed, void * out ) {
+  (void)seed;
+  *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).ll2);
+}
+
 
 inline void metrohash64_1_test ( const void * key, int len, uint32_t seed, void * out ) {
   metrohash64_1((const uint8_t *)key,(uint64_t)len,seed,(uint8_t *)out);

--- a/Hashes.h
+++ b/Hashes.h
@@ -77,6 +77,7 @@ void Crap8_test            ( const void * key, int len, uint32_t seed, void * ou
 
 void CityHash32_test       ( const void * key, int len, uint32_t seed, void * out );
 void CityHash64_test       ( const void * key, int len, uint32_t seed, void * out );
+void CityHash64noSeed_test ( const void * key, int len, uint32_t seed, void * out );
 void CityHash128_test      ( const void * key, int len, uint32_t seed, void * out );
 void FarmHash32_test       ( const void * key, int len, uint32_t seed, void * out );
 void FarmHash64_test       ( const void * key, int len, uint32_t seed, void * out );
@@ -204,7 +205,20 @@ inline void fasthash64_test ( const void * key, int len, uint32_t seed, void * o
   *(uint64_t*)out = fasthash64(key, (size_t) len, (uint64_t)seed);
 }
 
+
 void mum_hash_test(const void * key, int len, uint32_t seed, void * out);
+
+inline void mum_low_test ( const void * key, int len, uint32_t seed, void * out ) {
+  uint64_t result;
+  mum_hash_test(key, len, seed, &result);
+  *(uint32_t*)out = (uint32_t)result;
+}
+inline void mum_high_test ( const void * key, int len, uint32_t seed, void * out ) {
+  uint64_t result;
+  mum_hash_test(key, len, seed, &result);
+  *(uint32_t*)out = (uint32_t)(result>>32);
+}
+
 
 //-----------------------------------------------------------------------------
 

--- a/Hashes.h
+++ b/Hashes.h
@@ -160,17 +160,17 @@ inline void xxHash64_test( const void * key, int len, uint32_t seed, void * out 
 
 inline void xxh3_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
-  *(uint64_t*)out = (uint64_t) XXH3_64b_withSeed(key, (size_t) len, seed);
+  *(uint64_t*)out = (uint64_t) XXH3_64bits_withSeed(key, (size_t) len, seed);
 }
 
 inline void xxh3low_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
-  *(uint32_t*)out = (uint32_t) XXH3_64b(key, (size_t) len);
+  *(uint32_t*)out = (uint32_t) XXH3_64bits(key, (size_t) len);
 }
 
 inline void xxh3high_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
-  *(uint32_t*)out = (uint32_t) (XXH3_64b(key, (size_t) len) >> 32);
+  *(uint32_t*)out = (uint32_t) (XXH3_64bits(key, (size_t) len) >> 32);
 }
 
 inline void xxh128_test( const void * key, int len, uint32_t seed, void * out ) {
@@ -180,12 +180,12 @@ inline void xxh128_test( const void * key, int len, uint32_t seed, void * out ) 
 
 inline void xxh128low_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
-  *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).ll1);
+  *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).low64);
 }
 
 inline void xxh128high_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
-  *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).ll2);
+  *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).high64);
 }
 
 

--- a/Hashes.h
+++ b/Hashes.h
@@ -6,6 +6,7 @@
 #include "MurmurHash2.h"
 #include "MurmurHash3.h"
 
+#define XXH_INLINE_ALL
 #include "xxhash.h"
 #include "metrohash.h"
 #include "cmetrohash.h"
@@ -134,12 +135,32 @@ inline void jodyhash64_test( const void * key, int len, uint32_t seed, void * ou
   *(uint64_t*)out = jody_block_hash((const jodyhash_t *)key, (jodyhash_t) seed, (size_t) len);
 }
 
+
 inline void xxHash32_test( const void * key, int len, uint32_t seed, void * out ) {
   *(uint32_t*)out = (uint32_t) XXH32(key, (size_t) len, (unsigned) seed);
 }
 inline void xxHash64_test( const void * key, int len, uint32_t seed, void * out ) {
   *(uint64_t*)out = (uint64_t) XXH64(key, (size_t) len, (unsigned long long) seed);
 }
+
+#define restrict // oddly enough, seems to choke on this keyword
+#include "xxh3.h"
+
+inline void xxh3_test( const void * key, int len, uint32_t seed, void * out ) {
+  (void)seed;
+  *(uint64_t*)out = (uint64_t) XXH3_64b(key, (size_t) len);
+}
+
+inline void xxh3low_test( const void * key, int len, uint32_t seed, void * out ) {
+  (void)seed;
+  *(uint32_t*)out = (uint32_t) XXH3_64b(key, (size_t) len);
+}
+
+inline void xxh3high_test( const void * key, int len, uint32_t seed, void * out ) {
+  (void)seed;
+  *(uint32_t*)out = (uint32_t) (XXH3_64b(key, (size_t) len) >> 32);
+}
+
 
 inline void metrohash64_1_test ( const void * key, int len, uint32_t seed, void * out ) {
   metrohash64_1((const uint8_t *)key,(uint64_t)len,seed,(uint8_t *)out);

--- a/KeysetTest.cpp
+++ b/KeysetTest.cpp
@@ -71,7 +71,7 @@ bool VerificationTest ( pfHash hash, const int hashbits, uint32_t expected, bool
 bool SanityTest ( pfHash hash, const int hashbits )
 {
   printf("Running sanity check 1    ");
-  
+
   Rand r(883741);
 
   bool result = true;
@@ -81,7 +81,7 @@ bool SanityTest ( pfHash hash, const int hashbits )
   const int keymax = 256;
   const int pad = 16;
   const int buflen = keymax + pad*3;
-  
+
   uint8_t * buffer1 = new uint8_t[buflen];
   uint8_t * buffer2 = new uint8_t[buflen];
 
@@ -89,7 +89,7 @@ bool SanityTest ( pfHash hash, const int hashbits )
   uint8_t * hash2 = new uint8_t[hashbytes];
 
   //----------
-  
+
   for(int irep = 0; irep < reps; irep++)
   {
     if(irep % (reps/10) == 0) printf(".");
@@ -159,7 +159,7 @@ bool SanityTest ( pfHash hash, const int hashbits )
 void AppendedZeroesTest ( pfHash hash, const int hashbits )
 {
   printf("Running AppendedZeroesTest");
-  
+
   Rand r(173994);
 
   const int hashbytes = hashbits/8;
@@ -213,7 +213,7 @@ void TwoBytesKeygen ( int maxlen, KeyCallback & c )
 
   for(int i = 2; i <= maxlen; i++) keycount += i*255;
 
-  printf("Keyset 'TwoBytes' - up-to-%d-byte keys, %d total keys\n",maxlen, keycount);
+  printf("Keyset 'TwoBytes' - up-to-%d-byte keys, %d total keys\n", maxlen, keycount);
 
   c.reserve(keycount);
 

--- a/KeysetTest.h
+++ b/KeysetTest.h
@@ -49,26 +49,6 @@ void CombinationKeygenRecurse ( blocktype * key, int len, int maxlen,
     {
       hashtype h;
       hash(key, (len+1) * sizeof(blocktype), 0, &h);
-#if 0
-
-      unsigned uh; memcpy(&uh, &h, sizeof(uh));;
-      if (uh == 0x7B1F1626) {
-          printf("hash value == 0x%08X for : ", 0x7B1F1626);
-          printKey(key, (len+1) * sizeof(blocktype));
-      }
-
-#elif 0
-      if (std::find(hashes.begin(), hashes.end(), h) != hashes.end()) {
-         printf("collision found (len=%2zu): ", (len+1) * sizeof(blocktype));
-         printKey(key, (len+1) * sizeof(blocktype));
-#  if 1
-         unsigned uh;
-         memcpy(&uh, &h, sizeof(uh));
-         printf(" ===> %08X", uh);
-#  endif
-         printf(" \n");
-       }
-#endif
       hashes.push_back(h);
     }
 
@@ -198,25 +178,6 @@ void SparseKeygenRecurse ( pfHash hash, int start, int bitsleft, bool inclusive,
     if(inclusive || (bitsleft == 1))
     {
       hash(&k, sizeof(keytype), 0, &h);
-#if 0
-    if (std::find(hashes.begin(), hashes.end(), h) != hashes.end()) {
-       printf("collision found (len=%2zu): ", sizeof(keytype));
-       printSparseKey(&k, sizeof(keytype));
-    #  if 1
-       unsigned uh;
-       memcpy(&uh, &h, sizeof(uh));
-       printf(" ===> %08X", uh);
-    #  endif
-       printf(" \n");
-     }
-#elif 0
-      unsigned uh; memcpy(&uh, &h, sizeof(uh));
-      if ( uh == 0x52A0D13C
-         ) {
-         printf("\nh:0x%08X ==> ", uh);
-         printSparseKey(&k, sizeof(keytype));
-      }
-#endif
       hashes.push_back(h);
     }
 

--- a/Stats.h
+++ b/Stats.h
@@ -39,7 +39,7 @@ inline uint32_t f3mix ( uint32_t k )
 // the first N collisions for further processing
 
 template< typename hashtype >
-int FindCollisions ( std::vector<hashtype> & hashes, 
+int FindCollisions ( std::vector<hashtype> & hashes,
                      HashSet<hashtype> & collisions,
                      int maxCollisions )
 {
@@ -47,15 +47,16 @@ int FindCollisions ( std::vector<hashtype> & hashes,
 
   std::sort(hashes.begin(),hashes.end());
 
-  for(size_t i = 1; i < hashes.size(); i++)
+  for(size_t hnb = 1; hnb < hashes.size(); hnb++)
   {
-    if(hashes[i] == hashes[i-1])
+    if(hashes[hnb] == hashes[hnb-1])
     {
+      //unsigned uh; memcpy(&uh, &hashes[hnb], sizeof(uh)); printf("collision found : 0x%08X \n", uh);
       collcount++;
 
       if((int)collisions.size() < maxCollisions)
       {
-        collisions.insert(hashes[i]);
+        collisions.insert(hashes[hnb]);
       }
     }
   }
@@ -224,11 +225,12 @@ bool TestHashList ( std::vector<hashtype> & hashes, std::vector<hashtype> & coll
     else
     {
       // For all hashes larger than 32 bits, _any_ collisions are a failure.
-      
+
       if(collcount > 0)
       {
         printf(" !!!!! ");
         result = false;
+        //PrintCollisions(hashes, collisions);
       }
     }
 
@@ -290,7 +292,7 @@ bool TestKeyList ( hashfunc<hashtype> hash, std::vector<keytype> & keys, bool te
 // Bytepair test - generate 16-bit indices from all possible non-overlapping
 // 8-bit sections of the hash value, check distribution on all of them.
 
-// This is a very good test for catching weak intercorrelations between bits - 
+// This is a very good test for catching weak intercorrelations between bits -
 // much harder to pass than the normal distribution test. However, it doesn't
 // really model the normal usage of hash functions in hash table lookup, so
 // I'm not sure it's that useful (and hash functions that fail this test but
@@ -301,7 +303,7 @@ double TestDistributionBytepairs ( std::vector<hashtype> & hashes, bool drawDiag
 {
   const int nbytes = sizeof(hashtype);
   const int hashbits = nbytes * 8;
-  
+
   const int nbins = 65536;
 
   std::vector<int> bins(nbins,0);
@@ -355,7 +357,7 @@ void TestDistributionFast ( std::vector<hashtype> & hashes, double & dworst, dou
 {
   const int hashbits = sizeof(hashtype) * 8;
   const int nbins = 65536;
-  
+
   std::vector<int> bins(nbins,0);
 
   dworst = -1.0e90;
@@ -376,7 +378,7 @@ void TestDistributionFast ( std::vector<hashtype> & hashes, double & dworst, dou
     }
 
     double n = calcScore(&bins.front(),(int)bins.size(),(int)hashes.size());
-    
+
     davg += n;
 
     if(n > dworst) dworst = n;

--- a/Types.h
+++ b/Types.h
@@ -135,11 +135,6 @@ struct HashCallback : public KeyCallback
     hashtype h;
     m_pfHash(key, len, 0, &h);
     m_hashes.back() = h;
-#if 0  // debug : display specific keys
-    unsigned uh; memcpy(&uh,&h,sizeof(uh));
-    if (uh == 0x1CE514E4) printKey(key, len);
-    if (uh == 0x1926156A) printKey(key, len);
-#endif
   }
 
   virtual void reserve ( int keycount )

--- a/Types.h
+++ b/Types.h
@@ -75,7 +75,7 @@ public:
     return m_hash;
   }
 
-  inline T operator () ( const void * key, const int len, const uint32_t seed ) 
+  inline T operator () ( const void * key, const int len, const uint32_t seed )
   {
     T result;
 
@@ -114,6 +114,8 @@ struct KeyCallback
 
 //----------
 
+static void printKey(const void* key, size_t len);
+
 template<typename hashtype>
 struct HashCallback : public KeyCallback
 {
@@ -127,10 +129,17 @@ struct HashCallback : public KeyCallback
   virtual void operator () ( const void * key, int len )
   {
     size_t newsize = m_hashes.size() + 1;
-    
+
     m_hashes.resize(newsize);
 
-    m_pfHash(key,len,0,&m_hashes.back());
+    hashtype h;
+    m_pfHash(key, len, 0, &h);
+    m_hashes.back() = h;
+#if 0  // debug : display specific keys
+    unsigned uh; memcpy(&uh,&h,sizeof(uh));
+    if (uh == 0x1CE514E4) printKey(key, len);
+    if (uh == 0x1926156A) printKey(key, len);
+#endif
   }
 
   virtual void reserve ( int keycount )
@@ -156,8 +165,8 @@ struct CollisionCallback : public KeyCallback
   typedef HashSet<hashtype> hashset;
   typedef CollisionMap<hashtype,ByteVec> collmap;
 
-  CollisionCallback ( pfHash hash, hashset & collisions, collmap & cmap ) 
-  : m_pfHash(hash), 
+  CollisionCallback ( pfHash hash, hashset & collisions, collmap & cmap )
+  : m_pfHash(hash),
     m_collisions(collisions),
     m_collmap(cmap)
   {
@@ -168,7 +177,7 @@ struct CollisionCallback : public KeyCallback
     hashtype h;
 
     m_pfHash(key,len,0,&h);
-    
+
     if(m_collisions.count(h))
     {
       m_collmap[h].push_back( ByteVec(key,len) );
@@ -264,7 +273,7 @@ public:
 
   //----------
   // boolean operations
-  
+
   bool operator < ( const Blob & k ) const
   {
     for(size_t i = 0; i < sizeof(bytes); i++)
@@ -294,7 +303,7 @@ public:
   //----------
   // bitwise operations
 
-  Blob operator ^ ( const Blob & k ) const 
+  Blob operator ^ ( const Blob & k ) const
   {
     Blob t;
 
@@ -362,7 +371,7 @@ public:
   }
 
   //----------
-  
+
 private:
 
   uint8_t bytes[(_bits+7)/8];

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,5 @@ Linux)   CXX=g++ CC=gcc cmake .. ;;
 *)       CXX=clang++-4.0  CC=clang-4.0 cmake ..   ;;
 esac
 make -j4 $@
+cp SMHasher ..
 cd ..

--- a/doc/City64high
+++ b/doc/City64high
@@ -1,0 +1,489 @@
+-------------------------------------------------------------------------------
+--- Testing City64high "Google CityHash64WithSeed (high 32-bits)"
+
+[[[ Sanity Tests ]]]
+
+Verification value 0xC94A0E6B : PASS
+Running sanity check 1    ..........PASS
+Running AppendedZeroesTest..........PASS
+
+[[[ Speed Tests ]]]
+
+Bulk speed test - 262144-byte keys
+Alignment  7 -  4.142 bytes/cycle - 11851.67 MiB/sec @ 3 ghz
+Alignment  6 -  4.142 bytes/cycle - 11850.66 MiB/sec @ 3 ghz
+Alignment  5 -  4.142 bytes/cycle - 11849.07 MiB/sec @ 3 ghz
+Alignment  4 -  4.143 bytes/cycle - 11851.80 MiB/sec @ 3 ghz
+Alignment  3 -  4.142 bytes/cycle - 11850.48 MiB/sec @ 3 ghz
+Alignment  2 -  4.141 bytes/cycle - 11847.77 MiB/sec @ 3 ghz
+Alignment  1 -  4.071 bytes/cycle - 11646.73 MiB/sec @ 3 ghz
+Alignment  0 -  4.277 bytes/cycle - 12236.95 MiB/sec @ 3 ghz
+Average      -  4.150 bytes/cycle - 11873.14 MiB/sec @ 3 ghz
+
+Small key speed test -    1-byte keys -    40.00 cycles/hash
+Small key speed test -    2-byte keys -    41.00 cycles/hash
+Small key speed test -    3-byte keys -    41.00 cycles/hash
+Small key speed test -    4-byte keys -    43.00 cycles/hash
+Small key speed test -    5-byte keys -    54.00 cycles/hash
+Small key speed test -    6-byte keys -    54.00 cycles/hash
+Small key speed test -    7-byte keys -    54.00 cycles/hash
+Small key speed test -    8-byte keys -    43.00 cycles/hash
+Small key speed test -    9-byte keys -    56.00 cycles/hash
+Small key speed test -   10-byte keys -    56.14 cycles/hash
+Small key speed test -   11-byte keys -    56.00 cycles/hash
+Small key speed test -   12-byte keys -    55.00 cycles/hash
+Small key speed test -   13-byte keys -    54.99 cycles/hash
+Small key speed test -   14-byte keys -    55.00 cycles/hash
+Small key speed test -   15-byte keys -    55.00 cycles/hash
+Small key speed test -   16-byte keys -    54.83 cycles/hash
+Small key speed test -   17-byte keys -    61.00 cycles/hash
+Small key speed test -   18-byte keys -    61.00 cycles/hash
+Small key speed test -   19-byte keys -    61.00 cycles/hash
+Small key speed test -   20-byte keys -    61.00 cycles/hash
+Small key speed test -   21-byte keys -    61.00 cycles/hash
+Small key speed test -   22-byte keys -    61.00 cycles/hash
+Small key speed test -   23-byte keys -    61.00 cycles/hash
+Small key speed test -   24-byte keys -    61.00 cycles/hash
+Small key speed test -   25-byte keys -    61.00 cycles/hash
+Small key speed test -   26-byte keys -    61.00 cycles/hash
+Small key speed test -   27-byte keys -    61.00 cycles/hash
+Small key speed test -   28-byte keys -    61.00 cycles/hash
+Small key speed test -   29-byte keys -    61.00 cycles/hash
+Small key speed test -   30-byte keys -    61.00 cycles/hash
+Small key speed test -   31-byte keys -    61.00 cycles/hash
+Average                                    55.740 cycles/hash
+
+[[[ Avalanche Tests ]]]
+
+Testing  32-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.570667%
+Testing  40-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.584000%
+Testing  48-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.676667%
+Testing  56-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.619333%
+Testing  64-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.662000%
+Testing  72-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.852000%
+Testing  80-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.644667%
+Testing  96-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.638000%
+Testing 112-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.700667%
+Testing 128-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.708667%
+Testing 160-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.701333%
+Testing 192-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.768667%
+Testing 224-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.734000%
+Testing 256-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.623333%
+Testing 320-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.704667%
+Testing 384-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.726667%
+Testing 448-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.763333%
+Testing 512-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.724000%
+Testing 640-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.754667%
+Testing 768-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.780667%
+Testing 896-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.704000%
+Testing 1024-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.776000%
+Testing 1280-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.814000%
+Testing 1536-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.859333%
+
+[[[ Keyset 'Cyclic' Tests ]]]
+
+Keyset 'Cyclic' - 8 cycles of 4 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11606.00 ( 1.00x)
+Testing distribution - Worst bias is the  19-bit window at bit   1 - 0.017%
+
+Keyset 'Cyclic' - 8 cycles of 5 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11540.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.024%
+
+Keyset 'Cyclic' - 8 cycles of 6 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11686.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  20 - 0.021%
+
+Keyset 'Cyclic' - 8 cycles of 7 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11720.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.036%
+
+Keyset 'Cyclic' - 8 cycles of 8 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11603.00 ( 1.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  15 - 0.023%
+
+Keyset 'Cyclic' - 8 cycles of 12 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11913.00 ( 1.02x)
+Testing distribution - Worst bias is the  20-bit window at bit  20 - 0.033%
+
+
+[[[ Keyset 'TwoBytes' Tests ]]]
+
+Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
+Testing collisions   - Expected    49.57, actual    40.00 ( 0.81x)
+Testing distribution - Worst bias is the  16-bit window at bit  13 - 0.085%
+
+Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
+Testing collisions   - Expected  3484.56, actual  3482.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   0 - 0.066%
+
+Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
+Testing collisions   - Expected 40347.77, actual 40141.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  16 - 0.030%
+
+Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
+Testing collisions   - Expected 227963.15, actual 227405.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.007%
+
+Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
+Testing collisions   - Expected 871784.70, actual 867370.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.004%
+
+Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
+Testing collisions   - Expected 2606569.03, actual 2578178.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  22 - 0.001%
+
+
+[[[ Keyset 'Sparse' Tests ]]]
+
+Keyset 'Sparse' - 32-bit keys with up to 6 bits set - 1149017 keys
+Testing collisions   - Expected   153.70, actual   160.00 ( 1.04x)
+Testing distribution - Worst bias is the  17-bit window at bit   1 - 0.064%
+
+Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
+Testing collisions   - Expected  2461.72, actual  2541.00 ( 1.03x)
+Testing distribution - Worst bias is the  19-bit window at bit  18 - 0.053%
+
+Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
+Testing collisions   - Expected 23463.63, actual 23471.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  30 - 0.011%
+
+Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
+Testing collisions   - Expected  2069.66, actual  2106.00 ( 1.02x)
+Testing distribution - Worst bias is the  19-bit window at bit  22 - 0.041%
+
+Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
+Testing collisions   - Expected  8026.87, actual  8039.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.033%
+
+Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
+Testing collisions   - Expected 26482.73, actual 26309.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.020%
+
+Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
+Testing collisions   - Expected  1401.34, actual  1447.00 ( 1.03x)
+Testing distribution - Worst bias is the  19-bit window at bit   2 - 0.068%
+
+Keyset 'Sparse' - 112-bit keys with up to 4 bits set - 6445069 keys
+Testing collisions   - Expected  4835.77, actual  4706.00 ( 0.97x)
+Testing distribution - Worst bias is the  20-bit window at bit  31 - 0.042%
+
+Keyset 'Sparse' - 128-bit keys with up to 4 bits set - 11017633 keys
+Testing collisions   - Expected 14131.45, actual 13908.00 ( 0.98x)
+Testing distribution - Worst bias is the  20-bit window at bit  30 - 0.027%
+
+Keyset 'Sparse' - 144-bit keys with up to 4 bits set - 17676661 keys
+Testing collisions   - Expected 36375.64, actual 36319.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.019%
+
+Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
+Testing collisions   - Expected 84723.25, actual 84960.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  29 - 0.013%
+
+Keyset 'Sparse' - 192-bit keys with up to 4 bits set - 56050289 keys
+Testing collisions   - Expected 365734.43, actual 364270.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  17 - 0.006%
+
+Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
+Testing collisions   - Expected   910.36, actual   938.00 ( 1.03x)
+Testing distribution - Worst bias is the  19-bit window at bit  15 - 0.100%
+
+Keyset 'Sparse' - 288-bit keys with up to 3 bits set - 3981553 keys
+Testing collisions   - Expected  1845.50, actual  1808.00 ( 0.98x)
+Testing distribution - Worst bias is the  18-bit window at bit  31 - 0.036%
+
+Keyset 'Sparse' - 320-bit keys with up to 3 bits set - 5461601 keys
+Testing collisions   - Expected  3472.56, actual  3491.00 ( 1.01x)
+Testing distribution - Worst bias is the  19-bit window at bit  26 - 0.039%
+
+Keyset 'Sparse' - 384-bit keys with up to 3 bits set - 9437505 keys
+Testing collisions   - Expected 10368.70, actual 10334.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   2 - 0.024%
+
+Keyset 'Sparse' - 448-bit keys with up to 3 bits set - 14986273 keys
+Testing collisions   - Expected 26145.53, actual 26312.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  19 - 0.018%
+
+Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
+Testing collisions   - Expected 58256.45, actual 58043.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.014%
+
+Keyset 'Sparse' - 640-bit keys with up to 3 bits set - 43691201 keys
+Testing collisions   - Expected 222227.65, actual 222069.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.009%
+
+Keyset 'Sparse' - 768-bit keys with up to 3 bits set - 75498113 keys
+Testing collisions   - Expected 663563.26, actual 658267.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.004%
+
+Keyset 'Sparse' - 896-bit keys with up to 2 bits set - 401857 keys
+Testing collisions   - Expected    18.80, actual    12.00 ( 0.64x)
+Testing distribution - Worst bias is the  16-bit window at bit  17 - 0.154%
+
+Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
+Testing collisions   - Expected    32.06, actual    31.00 ( 0.97x)
+Testing distribution - Worst bias is the  16-bit window at bit  30 - 0.051%
+
+Keyset 'Sparse' - 1280-bit keys with up to 2 bits set - 819841 keys
+Testing collisions   - Expected    78.25, actual    89.00 ( 1.14x)
+Testing distribution - Worst bias is the  16-bit window at bit  16 - 0.092%
+
+Keyset 'Sparse' - 1536-bit keys with up to 2 bits set - 1180417 keys
+Testing collisions   - Expected   162.21, actual   159.00 ( 0.98x)
+Testing distribution - Worst bias is the  17-bit window at bit  30 - 0.096%
+
+Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
+Testing collisions   - Expected   512.50, actual   543.00 ( 1.06x)
+Testing distribution - Worst bias is the  17-bit window at bit   9 - 0.048%
+
+Keyset 'Sparse' - 3072-bit keys with up to 2 bits set - 4720129 keys
+Testing collisions   - Expected  2593.69, actual  2676.00 ( 1.03x)
+Testing distribution - Worst bias is the  19-bit window at bit   5 - 0.038%
+
+Keyset 'Sparse' - 4096-bit keys with up to 2 bits set - 8390657 keys
+Testing collisions   - Expected  8196.00, actual  8156.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  10 - 0.037%
+
+Keyset 'Sparse' - 6144-bit keys with up to 2 bits set - 18877441 keys
+Testing collisions   - Expected 41485.50, actual 41437.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  20 - 0.017%
+
+Keyset 'Sparse' - 8192-bit keys with up to 2 bits set - 33558529 keys
+Testing collisions   - Expected 131104.01, actual 130611.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.013%
+
+Keyset 'Sparse' - 9992-bit keys with up to 2 bits set - 49925029 keys
+Testing collisions   - Expected 290166.18, actual 289518.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.005%
+
+
+[[[ Keyset 'Combination Lowbits' Tests ]]]
+
+Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
+Testing collisions   - Expected 42799.01, actual 42305.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  10 - 0.010%
+
+
+[[[ Keyset 'Combination Highbits' Tests ]]]
+
+Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
+Testing collisions   - Expected 42799.01, actual 42684.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  27 - 0.009%
+
+
+[[[ Keyset 'Combination 0x8000000' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32823.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.013%
+
+
+[[[ Keyset 'Combination 0x0000001' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32479.00 ( 0.99x)
+Testing distribution - Worst bias is the  18-bit window at bit  10 - 0.010%
+
+
+[[[ Keyset 'Combination 0x800000000000000' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32609.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   0 - 0.017%
+
+
+[[[ Keyset 'Combination 0x000000000000001' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32766.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.019%
+
+
+[[[ Keyset 'Combination 16-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32800.00 ( 1.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  20 - 0.010%
+
+
+[[[ Keyset 'Combination 16-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32879.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   0 - 0.020%
+
+
+[[[ Keyset 'Combination 32-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32606.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.017%
+
+
+[[[ Keyset 'Combination 32-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32615.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   5 - 0.019%
+
+
+[[[ Keyset 'Combination 64-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32896.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  19 - 0.016%
+
+
+[[[ Keyset 'Combination 64-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32837.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.014%
+
+
+[[[ Keyset 'Combination 128-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32423.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.018%
+
+
+[[[ Keyset 'Combination 128-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32572.00 ( 0.99x)
+Testing distribution - Worst bias is the  19-bit window at bit  12 - 0.016%
+
+
+[[[ Keyset 'Combination Hi-Lo' Tests ]]]
+
+Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
+Testing collisions   - Expected 17339.30, actual 17491.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  20 - 0.023%
+
+
+[[[ Keyset 'Window' Tests ]]]
+
+Keyset 'Windowed' -  72-bit key,  20-bit window - 72 tests, 1048576 keys per test
+Window at   0 - Testing collisions   - Expected   128.00, actual   135.00 ( 1.05x)
+Window at   1 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at   2 - Testing collisions   - Expected   128.00, actual   114.00 ( 0.89x)
+Window at   3 - Testing collisions   - Expected   128.00, actual   130.00 ( 1.02x)
+Window at   4 - Testing collisions   - Expected   128.00, actual   149.00 ( 1.16x)
+Window at   5 - Testing collisions   - Expected   128.00, actual   121.00 ( 0.95x)
+Window at   6 - Testing collisions   - Expected   128.00, actual   111.00 ( 0.87x)
+Window at   7 - Testing collisions   - Expected   128.00, actual   109.00 ( 0.85x)
+Window at   8 - Testing collisions   - Expected   128.00, actual    99.00 ( 0.77x)
+Window at   9 - Testing collisions   - Expected   128.00, actual   101.00 ( 0.79x)
+Window at  10 - Testing collisions   - Expected   128.00, actual   105.00 ( 0.82x)
+Window at  11 - Testing collisions   - Expected   128.00, actual   114.00 ( 0.89x)
+Window at  12 - Testing collisions   - Expected   128.00, actual   119.00 ( 0.93x)
+Window at  13 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  14 - Testing collisions   - Expected   128.00, actual   137.00 ( 1.07x)
+Window at  15 - Testing collisions   - Expected   128.00, actual   142.00 ( 1.11x)
+Window at  16 - Testing collisions   - Expected   128.00, actual   131.00 ( 1.02x)
+Window at  17 - Testing collisions   - Expected   128.00, actual   129.00 ( 1.01x)
+Window at  18 - Testing collisions   - Expected   128.00, actual   102.00 ( 0.80x)
+Window at  19 - Testing collisions   - Expected   128.00, actual   125.00 ( 0.98x)
+Window at  20 - Testing collisions   - Expected   128.00, actual   133.00 ( 1.04x)
+Window at  21 - Testing collisions   - Expected   128.00, actual   134.00 ( 1.05x)
+Window at  22 - Testing collisions   - Expected   128.00, actual   129.00 ( 1.01x)
+Window at  23 - Testing collisions   - Expected   128.00, actual   110.00 ( 0.86x)
+Window at  24 - Testing collisions   - Expected   128.00, actual   133.00 ( 1.04x)
+Window at  25 - Testing collisions   - Expected   128.00, actual   134.00 ( 1.05x)
+Window at  26 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  27 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at  28 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  29 - Testing collisions   - Expected   128.00, actual   124.00 ( 0.97x)
+Window at  30 - Testing collisions   - Expected   128.00, actual   136.00 ( 1.06x)
+Window at  31 - Testing collisions   - Expected   128.00, actual   120.00 ( 0.94x)
+Window at  32 - Testing collisions   - Expected   128.00, actual   127.00 ( 0.99x)
+Window at  33 - Testing collisions   - Expected   128.00, actual   111.00 ( 0.87x)
+Window at  34 - Testing collisions   - Expected   128.00, actual   120.00 ( 0.94x)
+Window at  35 - Testing collisions   - Expected   128.00, actual   123.00 ( 0.96x)
+Window at  36 - Testing collisions   - Expected   128.00, actual   116.00 ( 0.91x)
+Window at  37 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at  38 - Testing collisions   - Expected   128.00, actual   132.00 ( 1.03x)
+Window at  39 - Testing collisions   - Expected   128.00, actual   103.00 ( 0.80x)
+Window at  40 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at  41 - Testing collisions   - Expected   128.00, actual   125.00 ( 0.98x)
+Window at  42 - Testing collisions   - Expected   128.00, actual   138.00 ( 1.08x)
+Window at  43 - Testing collisions   - Expected   128.00, actual   120.00 ( 0.94x)
+Window at  44 - Testing collisions   - Expected   128.00, actual   148.00 ( 1.16x)
+Window at  45 - Testing collisions   - Expected   128.00, actual   139.00 ( 1.09x)
+Window at  46 - Testing collisions   - Expected   128.00, actual   143.00 ( 1.12x)
+Window at  47 - Testing collisions   - Expected   128.00, actual   133.00 ( 1.04x)
+Window at  48 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at  49 - Testing collisions   - Expected   128.00, actual   135.00 ( 1.05x)
+Window at  50 - Testing collisions   - Expected   128.00, actual   117.00 ( 0.91x)
+Window at  51 - Testing collisions   - Expected   128.00, actual   130.00 ( 1.02x)
+Window at  52 - Testing collisions   - Expected   128.00, actual   139.00 ( 1.09x)
+Window at  53 - Testing collisions   - Expected   128.00, actual   137.00 ( 1.07x)
+Window at  54 - Testing collisions   - Expected   128.00, actual   154.00 ( 1.20x)
+Window at  55 - Testing collisions   - Expected   128.00, actual   130.00 ( 1.02x)
+Window at  56 - Testing collisions   - Expected   128.00, actual   136.00 ( 1.06x)
+Window at  57 - Testing collisions   - Expected   128.00, actual   117.00 ( 0.91x)
+Window at  58 - Testing collisions   - Expected   128.00, actual   137.00 ( 1.07x)
+Window at  59 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at  60 - Testing collisions   - Expected   128.00, actual   131.00 ( 1.02x)
+Window at  61 - Testing collisions   - Expected   128.00, actual   116.00 ( 0.91x)
+Window at  62 - Testing collisions   - Expected   128.00, actual   124.00 ( 0.97x)
+Window at  63 - Testing collisions   - Expected   128.00, actual   116.00 ( 0.91x)
+Window at  64 - Testing collisions   - Expected   128.00, actual   141.00 ( 1.10x)
+Window at  65 - Testing collisions   - Expected   128.00, actual   142.00 ( 1.11x)
+Window at  66 - Testing collisions   - Expected   128.00, actual   141.00 ( 1.10x)
+Window at  67 - Testing collisions   - Expected   128.00, actual   134.00 ( 1.05x)
+Window at  68 - Testing collisions   - Expected   128.00, actual   109.00 ( 0.85x)
+Window at  69 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  70 - Testing collisions   - Expected   128.00, actual   126.00 ( 0.98x)
+Window at  71 - Testing collisions   - Expected   128.00, actual   126.00 ( 0.98x)
+Window at  72 - Testing collisions   - Expected   128.00, actual   135.00 ( 1.05x)
+
+[[[ Keyset 'Text' Tests ]]]
+
+Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
+Testing collisions   - Expected 25418.13, actual 25217.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.019%
+
+Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
+Testing collisions   - Expected 25418.13, actual 25464.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  29 - 0.019%
+
+Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
+Testing collisions   - Expected 25418.13, actual 25037.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  31 - 0.016%
+
+
+[[[ Keyset 'Zeroes' Tests ]]]
+
+Keyset 'Zeroes' - 204800 keys
+Testing collisions   - Expected     4.88, actual     2.00 ( 0.41x)
+Testing distribution - Worst bias is the  15-bit window at bit  27 - 0.294%
+
+
+[[[ Keyset 'Seed' Tests ]]]
+
+Keyset 'Seed' - 5000000 keys
+Testing collisions   - Expected  2910.38, actual  2919.00 ( 1.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  11 - 0.040%
+
+
+[[[ Differential Tests ]]]
+
+Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
+1000 reps, 8303632000 total tests, expecting 1.93 random collisions..........
+2 total collisions, of which 2 single collisions were ignored
+
+Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 32 bit hashes.
+1000 reps, 11017632000 total tests, expecting 2.57 random collisions..........
+2 total collisions, of which 2 single collisions were ignored
+
+Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 32 bit hashes.
+1000 reps, 2796416000 total tests, expecting 0.65 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
+
+
+
+Input vcode 0x7b5a7bc8, Output vcode 0xf5b7b3c9, Result vcode 0x00000001
+Verification value is 0x00000001 - Testing took -1348.212192 seconds
+-------------------------------------------------------------------------------

--- a/doc/City64low
+++ b/doc/City64low
@@ -1,0 +1,489 @@
+-------------------------------------------------------------------------------
+--- Testing City64low "Google CityHash64WithSeed (low 32-bits)"
+
+[[[ Sanity Tests ]]]
+
+Verification value 0xCC5BC861 : PASS
+Running sanity check 1    ..........PASS
+Running AppendedZeroesTest..........PASS
+
+[[[ Speed Tests ]]]
+
+Bulk speed test - 262144-byte keys
+Alignment  7 -  4.140 bytes/cycle - 11844.77 MiB/sec @ 3 ghz
+Alignment  6 -  4.140 bytes/cycle - 11843.80 MiB/sec @ 3 ghz
+Alignment  5 -  4.140 bytes/cycle - 11843.44 MiB/sec @ 3 ghz
+Alignment  4 -  4.140 bytes/cycle - 11844.95 MiB/sec @ 3 ghz
+Alignment  3 -  4.140 bytes/cycle - 11845.51 MiB/sec @ 3 ghz
+Alignment  2 -  4.140 bytes/cycle - 11845.65 MiB/sec @ 3 ghz
+Alignment  1 -  4.140 bytes/cycle - 11844.99 MiB/sec @ 3 ghz
+Alignment  0 -  4.274 bytes/cycle - 12228.28 MiB/sec @ 3 ghz
+Average      -  4.157 bytes/cycle - 11892.67 MiB/sec @ 3 ghz
+
+Small key speed test -    1-byte keys -    38.56 cycles/hash
+Small key speed test -    2-byte keys -    39.00 cycles/hash
+Small key speed test -    3-byte keys -    39.00 cycles/hash
+Small key speed test -    4-byte keys -    41.14 cycles/hash
+Small key speed test -    5-byte keys -    52.00 cycles/hash
+Small key speed test -    6-byte keys -    52.00 cycles/hash
+Small key speed test -    7-byte keys -    51.99 cycles/hash
+Small key speed test -    8-byte keys -    41.00 cycles/hash
+Small key speed test -    9-byte keys -    54.18 cycles/hash
+Small key speed test -   10-byte keys -    54.19 cycles/hash
+Small key speed test -   11-byte keys -    54.19 cycles/hash
+Small key speed test -   12-byte keys -    52.99 cycles/hash
+Small key speed test -   13-byte keys -    52.97 cycles/hash
+Small key speed test -   14-byte keys -    52.98 cycles/hash
+Small key speed test -   15-byte keys -    52.99 cycles/hash
+Small key speed test -   16-byte keys -    52.89 cycles/hash
+Small key speed test -   17-byte keys -    59.00 cycles/hash
+Small key speed test -   18-byte keys -    59.00 cycles/hash
+Small key speed test -   19-byte keys -    59.00 cycles/hash
+Small key speed test -   20-byte keys -    59.00 cycles/hash
+Small key speed test -   21-byte keys -    59.00 cycles/hash
+Small key speed test -   22-byte keys -    59.00 cycles/hash
+Small key speed test -   23-byte keys -    59.00 cycles/hash
+Small key speed test -   24-byte keys -    59.00 cycles/hash
+Small key speed test -   25-byte keys -    59.00 cycles/hash
+Small key speed test -   26-byte keys -    59.00 cycles/hash
+Small key speed test -   27-byte keys -    59.00 cycles/hash
+Small key speed test -   28-byte keys -    59.00 cycles/hash
+Small key speed test -   29-byte keys -    59.00 cycles/hash
+Small key speed test -   30-byte keys -    59.00 cycles/hash
+Small key speed test -   31-byte keys -    59.00 cycles/hash
+Average                                    53.776 cycles/hash
+
+[[[ Avalanche Tests ]]]
+
+Testing  32-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.628000%
+Testing  40-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.567333%
+Testing  48-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.631333%
+Testing  56-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.711333%
+Testing  64-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.712667%
+Testing  72-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.636000%
+Testing  80-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.616000%
+Testing  96-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.744667%
+Testing 112-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.799333%
+Testing 128-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.703333%
+Testing 160-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.760000%
+Testing 192-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.683333%
+Testing 224-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.826667%
+Testing 256-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.677333%
+Testing 320-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.746667%
+Testing 384-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.771333%
+Testing 448-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.688667%
+Testing 512-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.704000%
+Testing 640-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.785333%
+Testing 768-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.708000%
+Testing 896-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.797333%
+Testing 1024-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.784000%
+Testing 1280-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.736667%
+Testing 1536-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 0.797333%
+
+[[[ Keyset 'Cyclic' Tests ]]]
+
+Keyset 'Cyclic' - 8 cycles of 4 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11371.00 ( 0.98x)
+Testing distribution - Worst bias is the  20-bit window at bit  16 - 0.026%
+
+Keyset 'Cyclic' - 8 cycles of 5 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11650.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.027%
+
+Keyset 'Cyclic' - 8 cycles of 6 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11616.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.019%
+
+Keyset 'Cyclic' - 8 cycles of 7 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11339.00 ( 0.97x)
+Testing distribution - Worst bias is the  20-bit window at bit  12 - 0.027%
+
+Keyset 'Cyclic' - 8 cycles of 8 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11499.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit   5 - 0.036%
+
+Keyset 'Cyclic' - 8 cycles of 12 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11653.00 ( 1.00x)
+Testing distribution - Worst bias is the  19-bit window at bit   4 - 0.024%
+
+
+[[[ Keyset 'TwoBytes' Tests ]]]
+
+Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
+Testing collisions   - Expected    49.57, actual    42.00 ( 0.85x)
+Testing distribution - Worst bias is the  16-bit window at bit  19 - 0.124%
+
+Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
+Testing collisions   - Expected  3484.56, actual  3548.00 ( 1.02x)
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.056%
+
+Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
+Testing collisions   - Expected 40347.77, actual 40453.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   2 - 0.022%
+
+Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
+Testing collisions   - Expected 227963.15, actual 227897.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  27 - 0.006%
+
+Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
+Testing collisions   - Expected 871784.70, actual 866712.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  14 - 0.004%
+
+Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
+Testing collisions   - Expected 2606569.03, actual 2575324.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.002%
+
+
+[[[ Keyset 'Sparse' Tests ]]]
+
+Keyset 'Sparse' - 32-bit keys with up to 6 bits set - 1149017 keys
+Testing collisions   - Expected   153.70, actual   152.00 ( 0.99x)
+Testing distribution - Worst bias is the  17-bit window at bit  29 - 0.097%
+
+Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
+Testing collisions   - Expected  2461.72, actual  2474.00 ( 1.00x)
+Testing distribution - Worst bias is the  19-bit window at bit   3 - 0.034%
+
+Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
+Testing collisions   - Expected 23463.63, actual 23687.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  28 - 0.016%
+
+Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
+Testing collisions   - Expected  2069.66, actual  2044.00 ( 0.99x)
+Testing distribution - Worst bias is the  19-bit window at bit  16 - 0.036%
+
+Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
+Testing collisions   - Expected  8026.87, actual  7953.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  19 - 0.030%
+
+Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
+Testing collisions   - Expected 26482.73, actual 26382.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  10 - 0.016%
+
+Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
+Testing collisions   - Expected  1401.34, actual  1314.00 ( 0.94x)
+Testing distribution - Worst bias is the  19-bit window at bit  31 - 0.042%
+
+Keyset 'Sparse' - 112-bit keys with up to 4 bits set - 6445069 keys
+Testing collisions   - Expected  4835.77, actual  4858.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.058%
+
+Keyset 'Sparse' - 128-bit keys with up to 4 bits set - 11017633 keys
+Testing collisions   - Expected 14131.45, actual 14177.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.018%
+
+Keyset 'Sparse' - 144-bit keys with up to 4 bits set - 17676661 keys
+Testing collisions   - Expected 36375.64, actual 35802.00 ( 0.98x)
+Testing distribution - Worst bias is the  19-bit window at bit  13 - 0.012%
+
+Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
+Testing collisions   - Expected 84723.25, actual 84313.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.007%
+
+Keyset 'Sparse' - 192-bit keys with up to 4 bits set - 56050289 keys
+Testing collisions   - Expected 365734.43, actual 362964.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  31 - 0.007%
+
+Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
+Testing collisions   - Expected   910.36, actual   845.00 ( 0.93x)
+Testing distribution - Worst bias is the  19-bit window at bit  28 - 0.069%
+
+Keyset 'Sparse' - 288-bit keys with up to 3 bits set - 3981553 keys
+Testing collisions   - Expected  1845.50, actual  1758.00 ( 0.95x)
+Testing distribution - Worst bias is the  19-bit window at bit  29 - 0.049%
+
+Keyset 'Sparse' - 320-bit keys with up to 3 bits set - 5461601 keys
+Testing collisions   - Expected  3472.56, actual  3425.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.049%
+
+Keyset 'Sparse' - 384-bit keys with up to 3 bits set - 9437505 keys
+Testing collisions   - Expected 10368.70, actual 10345.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.039%
+
+Keyset 'Sparse' - 448-bit keys with up to 3 bits set - 14986273 keys
+Testing collisions   - Expected 26145.53, actual 26172.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.022%
+
+Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
+Testing collisions   - Expected 58256.45, actual 58690.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.018%
+
+Keyset 'Sparse' - 640-bit keys with up to 3 bits set - 43691201 keys
+Testing collisions   - Expected 222227.65, actual 220782.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  16 - 0.006%
+
+Keyset 'Sparse' - 768-bit keys with up to 3 bits set - 75498113 keys
+Testing collisions   - Expected 663563.26, actual 658959.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.003%
+
+Keyset 'Sparse' - 896-bit keys with up to 2 bits set - 401857 keys
+Testing collisions   - Expected    18.80, actual    24.00 ( 1.28x)
+Testing distribution - Worst bias is the  16-bit window at bit  19 - 0.124%
+
+Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
+Testing collisions   - Expected    32.06, actual    34.00 ( 1.06x)
+Testing distribution - Worst bias is the  16-bit window at bit  29 - 0.160%
+
+Keyset 'Sparse' - 1280-bit keys with up to 2 bits set - 819841 keys
+Testing collisions   - Expected    78.25, actual    71.00 ( 0.91x)
+Testing distribution - Worst bias is the  17-bit window at bit  23 - 0.178%
+
+Keyset 'Sparse' - 1536-bit keys with up to 2 bits set - 1180417 keys
+Testing collisions   - Expected   162.21, actual   159.00 ( 0.98x)
+Testing distribution - Worst bias is the  17-bit window at bit   1 - 0.088%
+
+Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
+Testing collisions   - Expected   512.50, actual   491.00 ( 0.96x)
+Testing distribution - Worst bias is the  18-bit window at bit  31 - 0.101%
+
+Keyset 'Sparse' - 3072-bit keys with up to 2 bits set - 4720129 keys
+Testing collisions   - Expected  2593.69, actual  2554.00 ( 0.98x)
+Testing distribution - Worst bias is the  19-bit window at bit   1 - 0.038%
+
+Keyset 'Sparse' - 4096-bit keys with up to 2 bits set - 8390657 keys
+Testing collisions   - Expected  8196.00, actual  8233.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.037%
+
+Keyset 'Sparse' - 6144-bit keys with up to 2 bits set - 18877441 keys
+Testing collisions   - Expected 41485.50, actual 41364.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  22 - 0.024%
+
+Keyset 'Sparse' - 8192-bit keys with up to 2 bits set - 33558529 keys
+Testing collisions   - Expected 131104.01, actual 130547.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.013%
+
+Keyset 'Sparse' - 9992-bit keys with up to 2 bits set - 49925029 keys
+Testing collisions   - Expected 290166.18, actual 289327.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.006%
+
+
+[[[ Keyset 'Combination Lowbits' Tests ]]]
+
+Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
+Testing collisions   - Expected 42799.01, actual 42662.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.014%
+
+
+[[[ Keyset 'Combination Highbits' Tests ]]]
+
+Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
+Testing collisions   - Expected 42799.01, actual 42658.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  10 - 0.017%
+
+
+[[[ Keyset 'Combination 0x8000000' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 33028.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.025%
+
+
+[[[ Keyset 'Combination 0x0000001' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32541.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.026%
+
+
+[[[ Keyset 'Combination 0x800000000000000' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32628.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  27 - 0.015%
+
+
+[[[ Keyset 'Combination 0x000000000000001' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32517.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.016%
+
+
+[[[ Keyset 'Combination 16-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32843.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.021%
+
+
+[[[ Keyset 'Combination 16-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32668.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   5 - 0.011%
+
+
+[[[ Keyset 'Combination 32-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32481.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.017%
+
+
+[[[ Keyset 'Combination 32-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32695.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   1 - 0.016%
+
+
+[[[ Keyset 'Combination 64-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32665.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.018%
+
+
+[[[ Keyset 'Combination 64-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32755.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.021%
+
+
+[[[ Keyset 'Combination 128-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32532.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.015%
+
+
+[[[ Keyset 'Combination 128-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual 32505.00 ( 0.99x)
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.021%
+
+
+[[[ Keyset 'Combination Hi-Lo' Tests ]]]
+
+Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
+Testing collisions   - Expected 17339.30, actual 17059.00 ( 0.98x)
+Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.026%
+
+
+[[[ Keyset 'Window' Tests ]]]
+
+Keyset 'Windowed' -  72-bit key,  20-bit window - 72 tests, 1048576 keys per test
+Window at   0 - Testing collisions   - Expected   128.00, actual   152.00 ( 1.19x)
+Window at   1 - Testing collisions   - Expected   128.00, actual   144.00 ( 1.13x)
+Window at   2 - Testing collisions   - Expected   128.00, actual   138.00 ( 1.08x)
+Window at   3 - Testing collisions   - Expected   128.00, actual   136.00 ( 1.06x)
+Window at   4 - Testing collisions   - Expected   128.00, actual   145.00 ( 1.13x)
+Window at   5 - Testing collisions   - Expected   128.00, actual   124.00 ( 0.97x)
+Window at   6 - Testing collisions   - Expected   128.00, actual   141.00 ( 1.10x)
+Window at   7 - Testing collisions   - Expected   128.00, actual   156.00 ( 1.22x)
+Window at   8 - Testing collisions   - Expected   128.00, actual   139.00 ( 1.09x)
+Window at   9 - Testing collisions   - Expected   128.00, actual   133.00 ( 1.04x)
+Window at  10 - Testing collisions   - Expected   128.00, actual   144.00 ( 1.13x)
+Window at  11 - Testing collisions   - Expected   128.00, actual   126.00 ( 0.98x)
+Window at  12 - Testing collisions   - Expected   128.00, actual   119.00 ( 0.93x)
+Window at  13 - Testing collisions   - Expected   128.00, actual   134.00 ( 1.05x)
+Window at  14 - Testing collisions   - Expected   128.00, actual   136.00 ( 1.06x)
+Window at  15 - Testing collisions   - Expected   128.00, actual   141.00 ( 1.10x)
+Window at  16 - Testing collisions   - Expected   128.00, actual   121.00 ( 0.95x)
+Window at  17 - Testing collisions   - Expected   128.00, actual   100.00 ( 0.78x)
+Window at  18 - Testing collisions   - Expected   128.00, actual   124.00 ( 0.97x)
+Window at  19 - Testing collisions   - Expected   128.00, actual   111.00 ( 0.87x)
+Window at  20 - Testing collisions   - Expected   128.00, actual   142.00 ( 1.11x)
+Window at  21 - Testing collisions   - Expected   128.00, actual   127.00 ( 0.99x)
+Window at  22 - Testing collisions   - Expected   128.00, actual   147.00 ( 1.15x)
+Window at  23 - Testing collisions   - Expected   128.00, actual   124.00 ( 0.97x)
+Window at  24 - Testing collisions   - Expected   128.00, actual   120.00 ( 0.94x)
+Window at  25 - Testing collisions   - Expected   128.00, actual   118.00 ( 0.92x)
+Window at  26 - Testing collisions   - Expected   128.00, actual   130.00 ( 1.02x)
+Window at  27 - Testing collisions   - Expected   128.00, actual   115.00 ( 0.90x)
+Window at  28 - Testing collisions   - Expected   128.00, actual   107.00 ( 0.84x)
+Window at  29 - Testing collisions   - Expected   128.00, actual   119.00 ( 0.93x)
+Window at  30 - Testing collisions   - Expected   128.00, actual   132.00 ( 1.03x)
+Window at  31 - Testing collisions   - Expected   128.00, actual   120.00 ( 0.94x)
+Window at  32 - Testing collisions   - Expected   128.00, actual   110.00 ( 0.86x)
+Window at  33 - Testing collisions   - Expected   128.00, actual   116.00 ( 0.91x)
+Window at  34 - Testing collisions   - Expected   128.00, actual   131.00 ( 1.02x)
+Window at  35 - Testing collisions   - Expected   128.00, actual   145.00 ( 1.13x)
+Window at  36 - Testing collisions   - Expected   128.00, actual   131.00 ( 1.02x)
+Window at  37 - Testing collisions   - Expected   128.00, actual   116.00 ( 0.91x)
+Window at  38 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  39 - Testing collisions   - Expected   128.00, actual   133.00 ( 1.04x)
+Window at  40 - Testing collisions   - Expected   128.00, actual   137.00 ( 1.07x)
+Window at  41 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  42 - Testing collisions   - Expected   128.00, actual   127.00 ( 0.99x)
+Window at  43 - Testing collisions   - Expected   128.00, actual   121.00 ( 0.95x)
+Window at  44 - Testing collisions   - Expected   128.00, actual   140.00 ( 1.09x)
+Window at  45 - Testing collisions   - Expected   128.00, actual   113.00 ( 0.88x)
+Window at  46 - Testing collisions   - Expected   128.00, actual   126.00 ( 0.98x)
+Window at  47 - Testing collisions   - Expected   128.00, actual   133.00 ( 1.04x)
+Window at  48 - Testing collisions   - Expected   128.00, actual   135.00 ( 1.05x)
+Window at  49 - Testing collisions   - Expected   128.00, actual   129.00 ( 1.01x)
+Window at  50 - Testing collisions   - Expected   128.00, actual   117.00 ( 0.91x)
+Window at  51 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  52 - Testing collisions   - Expected   128.00, actual   113.00 ( 0.88x)
+Window at  53 - Testing collisions   - Expected   128.00, actual   125.00 ( 0.98x)
+Window at  54 - Testing collisions   - Expected   128.00, actual   134.00 ( 1.05x)
+Window at  55 - Testing collisions   - Expected   128.00, actual   122.00 ( 0.95x)
+Window at  56 - Testing collisions   - Expected   128.00, actual   123.00 ( 0.96x)
+Window at  57 - Testing collisions   - Expected   128.00, actual   142.00 ( 1.11x)
+Window at  58 - Testing collisions   - Expected   128.00, actual   144.00 ( 1.13x)
+Window at  59 - Testing collisions   - Expected   128.00, actual   125.00 ( 0.98x)
+Window at  60 - Testing collisions   - Expected   128.00, actual   123.00 ( 0.96x)
+Window at  61 - Testing collisions   - Expected   128.00, actual   120.00 ( 0.94x)
+Window at  62 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at  63 - Testing collisions   - Expected   128.00, actual   136.00 ( 1.06x)
+Window at  64 - Testing collisions   - Expected   128.00, actual   146.00 ( 1.14x)
+Window at  65 - Testing collisions   - Expected   128.00, actual   128.00 ( 1.00x)
+Window at  66 - Testing collisions   - Expected   128.00, actual   116.00 ( 0.91x)
+Window at  67 - Testing collisions   - Expected   128.00, actual   109.00 ( 0.85x)
+Window at  68 - Testing collisions   - Expected   128.00, actual   144.00 ( 1.13x)
+Window at  69 - Testing collisions   - Expected   128.00, actual   139.00 ( 1.09x)
+Window at  70 - Testing collisions   - Expected   128.00, actual   153.00 ( 1.20x)
+Window at  71 - Testing collisions   - Expected   128.00, actual   140.00 ( 1.09x)
+Window at  72 - Testing collisions   - Expected   128.00, actual   152.00 ( 1.19x)
+
+[[[ Keyset 'Text' Tests ]]]
+
+Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
+Testing collisions   - Expected 25418.13, actual 25729.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.019%
+
+Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
+Testing collisions   - Expected 25418.13, actual 25437.00 ( 1.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   2 - 0.021%
+
+Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
+Testing collisions   - Expected 25418.13, actual 25717.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.016%
+
+
+[[[ Keyset 'Zeroes' Tests ]]]
+
+Keyset 'Zeroes' - 204800 keys
+Testing collisions   - Expected     4.88, actual     5.00 ( 1.02x)
+Testing distribution - Worst bias is the  15-bit window at bit  27 - 0.201%
+
+
+[[[ Keyset 'Seed' Tests ]]]
+
+Keyset 'Seed' - 5000000 keys
+Testing collisions   - Expected  2910.38, actual  2879.00 ( 0.99x)
+Testing distribution - Worst bias is the  19-bit window at bit  13 - 0.056%
+
+
+[[[ Differential Tests ]]]
+
+Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
+1000 reps, 8303632000 total tests, expecting 1.93 random collisions..........
+3 total collisions, of which 3 single collisions were ignored
+
+Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 32 bit hashes.
+1000 reps, 11017632000 total tests, expecting 2.57 random collisions..........
+1 total collisions, of which 1 single collisions were ignored
+
+Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 32 bit hashes.
+1000 reps, 2796416000 total tests, expecting 0.65 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
+
+
+
+Input vcode 0x81ad21ba, Output vcode 0x4e9254d5, Result vcode 0x00000001
+Verification value is 0x00000001 - Testing took -1355.064439 seconds
+-------------------------------------------------------------------------------

--- a/doc/City64noSeed
+++ b/doc/City64noSeed
@@ -1,137 +1,138 @@
 -------------------------------------------------------------------------------
---- Testing City64 "Google CityHash64WithSeed (old)"
+--- Testing City64noSeed "Google CityHash64 without seed (default version, misses one final avalanche)"
 
 [[[ Sanity Tests ]]]
 
-Verification value 0x25A20825 : PASS
+Verification value 0x63FC6063 : PASS
 Running sanity check 1    ..........PASS
 Running AppendedZeroesTest..........PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  4.208 bytes/cycle - 12040.39 MiB/sec @ 3 ghz
-Alignment  6 -  4.209 bytes/cycle - 12043.35 MiB/sec @ 3 ghz
-Alignment  5 -  4.208 bytes/cycle - 12039.12 MiB/sec @ 3 ghz
-Alignment  4 -  4.209 bytes/cycle - 12042.73 MiB/sec @ 3 ghz
-Alignment  3 -  4.210 bytes/cycle - 12045.63 MiB/sec @ 3 ghz
-Alignment  2 -  4.211 bytes/cycle - 12048.23 MiB/sec @ 3 ghz
-Alignment  1 -  4.208 bytes/cycle - 12038.98 MiB/sec @ 3 ghz
-Alignment  0 -  4.336 bytes/cycle - 12406.79 MiB/sec @ 3 ghz
-Average      -  4.225 bytes/cycle - 12088.15 MiB/sec @ 3 ghz
+Alignment  7 -  4.156 bytes/cycle - 11890.90 MiB/sec @ 3 ghz
+Alignment  6 -  4.158 bytes/cycle - 11897.07 MiB/sec @ 3 ghz
+Alignment  5 -  4.161 bytes/cycle - 11903.42 MiB/sec @ 3 ghz
+Alignment  4 -  4.158 bytes/cycle - 11896.59 MiB/sec @ 3 ghz
+Alignment  3 -  4.160 bytes/cycle - 11901.41 MiB/sec @ 3 ghz
+Alignment  2 -  4.161 bytes/cycle - 11903.75 MiB/sec @ 3 ghz
+Alignment  1 -  4.161 bytes/cycle - 11903.66 MiB/sec @ 3 ghz
+Alignment  0 -  4.294 bytes/cycle - 12283.89 MiB/sec @ 3 ghz
+Average      -  4.176 bytes/cycle - 11947.59 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    36.00 cycles/hash
-Small key speed test -    2-byte keys -    37.00 cycles/hash
-Small key speed test -    3-byte keys -    37.00 cycles/hash
-Small key speed test -    4-byte keys -    38.00 cycles/hash
-Small key speed test -    5-byte keys -    49.00 cycles/hash
-Small key speed test -    6-byte keys -    49.00 cycles/hash
-Small key speed test -    7-byte keys -    49.00 cycles/hash
-Small key speed test -    8-byte keys -    38.12 cycles/hash
-Small key speed test -    9-byte keys -    52.00 cycles/hash
-Small key speed test -   10-byte keys -    51.99 cycles/hash
-Small key speed test -   11-byte keys -    52.00 cycles/hash
-Small key speed test -   12-byte keys -    50.00 cycles/hash
-Small key speed test -   13-byte keys -    50.00 cycles/hash
-Small key speed test -   14-byte keys -    50.00 cycles/hash
-Small key speed test -   15-byte keys -    50.00 cycles/hash
-Small key speed test -   16-byte keys -    49.94 cycles/hash
-Small key speed test -   17-byte keys -    56.00 cycles/hash
-Small key speed test -   18-byte keys -    56.00 cycles/hash
-Small key speed test -   19-byte keys -    56.00 cycles/hash
-Small key speed test -   20-byte keys -    56.00 cycles/hash
-Small key speed test -   21-byte keys -    56.00 cycles/hash
-Small key speed test -   22-byte keys -    56.00 cycles/hash
-Small key speed test -   23-byte keys -    56.00 cycles/hash
-Small key speed test -   24-byte keys -    55.99 cycles/hash
-Small key speed test -   25-byte keys -    56.00 cycles/hash
-Small key speed test -   26-byte keys -    56.00 cycles/hash
-Small key speed test -   27-byte keys -    56.00 cycles/hash
-Small key speed test -   28-byte keys -    56.00 cycles/hash
-Small key speed test -   29-byte keys -    56.00 cycles/hash
-Small key speed test -   30-byte keys -    56.00 cycles/hash
-Small key speed test -   31-byte keys -    56.00 cycles/hash
-Average                                    50.936 cycles/hash
+Small key speed test -    1-byte keys -    20.00 cycles/hash
+Small key speed test -    2-byte keys -    21.00 cycles/hash
+Small key speed test -    3-byte keys -    21.00 cycles/hash
+Small key speed test -    4-byte keys -    22.93 cycles/hash
+Small key speed test -    5-byte keys -    33.00 cycles/hash
+Small key speed test -    6-byte keys -    33.00 cycles/hash
+Small key speed test -    7-byte keys -    33.00 cycles/hash
+Small key speed test -    8-byte keys -    23.00 cycles/hash
+Small key speed test -    9-byte keys -    36.00 cycles/hash
+Small key speed test -   10-byte keys -    36.00 cycles/hash
+Small key speed test -   11-byte keys -    36.00 cycles/hash
+Small key speed test -   12-byte keys -    34.00 cycles/hash
+Small key speed test -   13-byte keys -    34.00 cycles/hash
+Small key speed test -   14-byte keys -    34.00 cycles/hash
+Small key speed test -   15-byte keys -    34.00 cycles/hash
+Small key speed test -   16-byte keys -    34.00 cycles/hash
+Small key speed test -   17-byte keys -    41.00 cycles/hash
+Small key speed test -   18-byte keys -    41.00 cycles/hash
+Small key speed test -   19-byte keys -    41.00 cycles/hash
+Small key speed test -   20-byte keys -    41.00 cycles/hash
+Small key speed test -   21-byte keys -    41.00 cycles/hash
+Small key speed test -   22-byte keys -    41.00 cycles/hash
+Small key speed test -   23-byte keys -    41.00 cycles/hash
+Small key speed test -   24-byte keys -    41.00 cycles/hash
+Small key speed test -   25-byte keys -    41.00 cycles/hash
+Small key speed test -   26-byte keys -    41.00 cycles/hash
+Small key speed test -   27-byte keys -    41.00 cycles/hash
+Small key speed test -   28-byte keys -    41.00 cycles/hash
+Small key speed test -   29-byte keys -    41.00 cycles/hash
+Small key speed test -   30-byte keys -    41.00 cycles/hash
+Small key speed test -   31-byte keys -    41.00 cycles/hash
+Average                                    35.481 cycles/hash
 
 [[[ Avalanche Tests ]]]
 
-Testing  32-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.628000%
-Testing  40-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.584000%
-Testing  48-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.676667%
-Testing  56-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.711333%
-Testing  64-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.712667%
-Testing  72-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.852000%
-Testing  80-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.644667%
-Testing  96-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.744667%
-Testing 112-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.799333%
-Testing 128-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.708667%
-Testing 160-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.760000%
-Testing 192-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.768667%
-Testing 224-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.826667%
-Testing 256-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.677333%
-Testing 320-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.746667%
-Testing 384-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.771333%
-Testing 448-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.763333%
-Testing 512-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.724000%
-Testing 640-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.785333%
-Testing 768-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.780667%
-Testing 896-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.797333%
-Testing 1024-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.784000%
-Testing 1280-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.814000%
-Testing 1536-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.859333%
+Testing  32-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 7.363333% !!!!! 
+Testing  40-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 1.081333% !!!!! 
+Testing  48-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.805333%
+Testing  56-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.719333%
+Testing  64-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 1.468000% !!!!! 
+Testing  72-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 4.304000% !!!!! 
+Testing  80-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 4.191333% !!!!! 
+Testing  96-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 1.923333% !!!!! 
+Testing 112-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 26.910000% !!!!! 
+Testing 128-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 83.715333% !!!!! 
+Testing 160-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.762000%
+Testing 192-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.699333%
+Testing 224-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 83.668667% !!!!! 
+Testing 256-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 83.950000% !!!!! 
+Testing 320-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 5.757333% !!!!! 
+Testing 384-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 5.669333% !!!!! 
+Testing 448-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 10.764667% !!!!! 
+Testing 512-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 10.434000% !!!!! 
+Testing 640-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.781333%
+Testing 768-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.823333%
+Testing 896-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.791333%
+Testing 1024-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.818000%
+Testing 1280-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.762000%
+Testing 1536-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.838667%
+*********FAIL*********
 
 [[[ Keyset 'Cyclic' Tests ]]]
 
 Keyset 'Cyclic' - 8 cycles of 8 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   5 - 0.036%
+Testing distribution - Worst bias is the  20-bit window at bit  14 - 0.034%
 
 Keyset 'Cyclic' - 8 cycles of 9 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  17 - 0.034%
+Testing distribution - Worst bias is the  20-bit window at bit  38 - 0.030%
 
 Keyset 'Cyclic' - 8 cycles of 10 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  44 - 0.028%
+Testing distribution - Worst bias is the  20-bit window at bit  61 - 0.035%
 
 Keyset 'Cyclic' - 8 cycles of 11 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.024%
+Testing distribution - Worst bias is the  20-bit window at bit  25 - 0.030%
 
 Keyset 'Cyclic' - 8 cycles of 12 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  28 - 0.039%
+Testing distribution - Worst bias is the  20-bit window at bit  55 - 0.040%
 
 Keyset 'Cyclic' - 8 cycles of 16 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.035%
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.045%
 
 
 [[[ Keyset 'TwoBytes' Tests ]]]
 
 Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  29 - 0.154%
+Testing distribution - Worst bias is the  16-bit window at bit  38 - 0.114%
 
 Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  31 - 0.086%
+Testing distribution - Worst bias is the  20-bit window at bit  46 - 0.049%
 
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   2 - 0.022%
+Testing distribution - Worst bias is the  20-bit window at bit   0 - 0.012%
 
 Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
 Testing collisions   - Expected     0.00, actual     1.00 (18840.62x) !!!!! 
-Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.007%
+Testing distribution - Worst bias is the  20-bit window at bit  11 - 0.013%
 
 Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 Testing collisions   - Expected     0.00, actual     1.00 (4926.64x) !!!!! 
-Testing distribution - Worst bias is the  20-bit window at bit  36 - 0.004%
+Testing distribution - Worst bias is the  20-bit window at bit  42 - 0.004%
 
 Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
 Testing collisions   - Expected     0.00, actual     1.00 (1647.75x) !!!!! 
-Testing distribution - Worst bias is the  20-bit window at bit  47 - 0.001%
+Testing distribution - Worst bias is the  20-bit window at bit  45 - 0.002%
 
 *********FAIL*********
 
@@ -139,123 +140,123 @@ Testing distribution - Worst bias is the  20-bit window at bit  47 - 0.001%
 
 Keyset 'Sparse' - 32-bit keys with up to 6 bits set - 1149017 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  17-bit window at bit   2 - 0.082%
+Testing distribution - Worst bias is the  17-bit window at bit  33 - 0.102%
 
 Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  62 - 0.042%
+Testing distribution - Worst bias is the  19-bit window at bit  29 - 0.035%
 
 Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  59 - 0.022%
+Testing distribution - Worst bias is the  20-bit window at bit  17 - 0.020%
 
 Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  60 - 0.052%
+Testing distribution - Worst bias is the  19-bit window at bit  17 - 0.061%
 
 Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  46 - 0.035%
+Testing distribution - Worst bias is the  20-bit window at bit  51 - 0.046%
 
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.021%
+Testing distribution - Worst bias is the  20-bit window at bit  61 - 0.019%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  34 - 0.068%
+Testing distribution - Worst bias is the  19-bit window at bit  11 - 0.072%
 
 Keyset 'Sparse' - 112-bit keys with up to 4 bits set - 6445069 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.058%
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.056%
 
 Keyset 'Sparse' - 128-bit keys with up to 4 bits set - 11017633 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  17 - 0.027%
+Testing distribution - Worst bias is the  20-bit window at bit  51 - 0.178%
 
 Keyset 'Sparse' - 144-bit keys with up to 4 bits set - 17676661 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  43 - 0.017%
+Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.017%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  62 - 0.012%
+Testing distribution - Worst bias is the  20-bit window at bit  14 - 0.016%
 
 Keyset 'Sparse' - 192-bit keys with up to 4 bits set - 56050289 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  38 - 0.006%
+Testing distribution - Worst bias is the  20-bit window at bit  22 - 0.007%
 
 Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  49 - 0.094%
+Testing distribution - Worst bias is the  19-bit window at bit  46 - 0.079%
 
 Keyset 'Sparse' - 288-bit keys with up to 3 bits set - 3981553 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit   9 - 0.049%
+Testing distribution - Worst bias is the  19-bit window at bit  16 - 0.084%
 
 Keyset 'Sparse' - 320-bit keys with up to 3 bits set - 5461601 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  25 - 0.077%
+Testing distribution - Worst bias is the  20-bit window at bit  10 - 0.050%
 
 Keyset 'Sparse' - 384-bit keys with up to 3 bits set - 9437505 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.039%
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.037%
 
 Keyset 'Sparse' - 448-bit keys with up to 3 bits set - 14986273 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.028%
+Testing distribution - Worst bias is the  20-bit window at bit  48 - 0.019%
 
 Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
 Testing collisions   - Expected     0.00, actual   217.00 (15998364.99x) !!!!! 
-Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.014%
+Testing distribution - Worst bias is the  20-bit window at bit  60 - 0.014%
 
 Keyset 'Sparse' - 640-bit keys with up to 3 bits set - 43691201 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  27 - 0.007%
+Testing distribution - Worst bias is the  19-bit window at bit  63 - 0.006%
 
 Keyset 'Sparse' - 768-bit keys with up to 3 bits set - 75498113 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  51 - 0.004%
+Testing distribution - Worst bias is the  20-bit window at bit  12 - 0.005%
 
 Keyset 'Sparse' - 896-bit keys with up to 2 bits set - 401857 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  30 - 0.108%
+Testing distribution - Worst bias is the  16-bit window at bit  58 - 0.188%
 
 Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  61 - 0.130%
+Testing distribution - Worst bias is the  16-bit window at bit  42 - 0.247%
 
 Keyset 'Sparse' - 1280-bit keys with up to 2 bits set - 819841 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  17-bit window at bit  48 - 0.109%
+Testing distribution - Worst bias is the  17-bit window at bit  22 - 0.116%
 
 Keyset 'Sparse' - 1536-bit keys with up to 2 bits set - 1180417 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  17-bit window at bit  63 - 0.090%
+Testing distribution - Worst bias is the  17-bit window at bit  41 - 0.146%
 
 Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  18-bit window at bit   0 - 0.099%
+Testing distribution - Worst bias is the  18-bit window at bit  27 - 0.123%
 
 Keyset 'Sparse' - 3072-bit keys with up to 2 bits set - 4720129 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  61 - 0.041%
+Testing distribution - Worst bias is the  19-bit window at bit   5 - 0.057%
 
 Keyset 'Sparse' - 4096-bit keys with up to 2 bits set - 8390657 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  42 - 0.037%
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.037%
 
 Keyset 'Sparse' - 6144-bit keys with up to 2 bits set - 18877441 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.017%
+Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.020%
 
 Keyset 'Sparse' - 8192-bit keys with up to 2 bits set - 33558529 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   2 - 0.010%
+Testing distribution - Worst bias is the  20-bit window at bit  40 - 0.009%
 
 Keyset 'Sparse' - 9992-bit keys with up to 2 bits set - 49925029 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.007%
+Testing distribution - Worst bias is the  20-bit window at bit  30 - 0.004%
 
 *********FAIL*********
 
@@ -263,105 +264,105 @@ Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.007%
 
 Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  60 - 0.021%
+Testing distribution - Worst bias is the  20-bit window at bit   1 - 0.016%
 
 
 [[[ Keyset 'Combination Highbits' Tests ]]]
 
 Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  10 - 0.017%
+Testing distribution - Worst bias is the  20-bit window at bit  63 - 0.018%
 
 
 [[[ Keyset 'Combination 0x8000000' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.025%
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.016%
 
 
 [[[ Keyset 'Combination 0x0000001' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.019%
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.020%
 
 
 [[[ Keyset 'Combination 0x800000000000000' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  28 - 0.019%
+Testing distribution - Worst bias is the  20-bit window at bit  12 - 0.016%
 
 
 [[[ Keyset 'Combination 0x000000000000001' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.023%
+Testing distribution - Worst bias is the  20-bit window at bit  22 - 0.014%
 
 
 [[[ Keyset 'Combination 16-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.021%
+Testing distribution - Worst bias is the  20-bit window at bit  12 - 0.019%
 
 
 [[[ Keyset 'Combination 16-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  32 - 0.020%
+Testing distribution - Worst bias is the  20-bit window at bit  31 - 0.023%
 
 
 [[[ Keyset 'Combination 32-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  59 - 0.012%
+Testing distribution - Worst bias is the  20-bit window at bit   0 - 0.020%
 
 
 [[[ Keyset 'Combination 32-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  52 - 0.022%
+Testing distribution - Worst bias is the  20-bit window at bit  43 - 0.018%
 
 
 [[[ Keyset 'Combination 64-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.015%
+Testing distribution - Worst bias is the  20-bit window at bit  31 - 0.027%
 
 
 [[[ Keyset 'Combination 64-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.018%
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.017%
 
 
 [[[ Keyset 'Combination 128-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  40 - 0.018%
+Testing distribution - Worst bias is the  20-bit window at bit  62 - 0.018%
 
 
 [[[ Keyset 'Combination 128-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.021%
+Testing distribution - Worst bias is the  20-bit window at bit  61 - 0.015%
 
 
 [[[ Keyset 'Combination Hi-Lo' Tests ]]]
 
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.026%
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.028%
 
 
 [[[ Keyset 'Window' Tests ]]]
@@ -501,30 +502,31 @@ Window at 128 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00
 
 Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  16 - 0.024%
+Testing distribution - Worst bias is the  20-bit window at bit  12 - 0.020%
 
 Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  59 - 0.025%
+Testing distribution - Worst bias is the  20-bit window at bit  45 - 0.031%
 
 Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  56 - 0.029%
+Testing distribution - Worst bias is the  20-bit window at bit  32 - 0.013%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
 
 Keyset 'Zeroes' - 204800 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  15-bit window at bit  35 - 0.268%
+Testing distribution - Worst bias is the  15-bit window at bit  20 - 0.265%
 
 
 [[[ Keyset 'Seed' Tests ]]]
 
 Keyset 'Seed' - 5000000 keys
-Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  13 - 0.056%
+Testing collisions   - Expected     0.00, actual 4999999.00 (7378697629483.82x) !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit   0 - 100.000% !!!!! 
 
+*********FAIL*********
 
 [[[ Differential Tests ]]]
 
@@ -543,5 +545,5 @@ Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 64 bit hashes.
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took -2112.188598 seconds
+Verification value is 0x00000001 - Testing took 2020.749877 seconds
 -------------------------------------------------------------------------------

--- a/doc/Farm64noSeed
+++ b/doc/Farm64noSeed
@@ -1,367 +1,366 @@
 -------------------------------------------------------------------------------
---- Testing FNV64 "Fowler-Noll-Vo hash, 64-bit"
+--- Testing Farm64noSeed "Google FarmHash64 without seed (default, misses on final avalanche)"
 
 [[[ Sanity Tests ]]]
 
-Verification value 0x103455FC : PASS
+Verification value 0xA5B9146C : PASS
 Running sanity check 1    ..........PASS
 Running AppendedZeroesTest..........PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Alignment  6 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Alignment  5 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Alignment  4 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Alignment  3 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Alignment  2 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Alignment  1 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Alignment  0 -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
-Average      -  0.250 bytes/cycle -  715.20 MiB/sec @ 3 ghz
+Alignment  7 -  6.964 bytes/cycle - 19925.52 MiB/sec @ 3 ghz
+Alignment  6 -  6.954 bytes/cycle - 19896.23 MiB/sec @ 3 ghz
+Alignment  5 -  6.953 bytes/cycle - 19893.17 MiB/sec @ 3 ghz
+Alignment  4 -  6.952 bytes/cycle - 19889.80 MiB/sec @ 3 ghz
+Alignment  3 -  6.966 bytes/cycle - 19928.69 MiB/sec @ 3 ghz
+Alignment  2 -  6.956 bytes/cycle - 19901.64 MiB/sec @ 3 ghz
+Alignment  1 -  6.962 bytes/cycle - 19918.42 MiB/sec @ 3 ghz
+Alignment  0 -  7.113 bytes/cycle - 20351.75 MiB/sec @ 3 ghz
+Average      -  6.978 bytes/cycle - 19963.15 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    13.00 cycles/hash
-Small key speed test -    2-byte keys -    15.00 cycles/hash
-Small key speed test -    3-byte keys -    20.00 cycles/hash
-Small key speed test -    4-byte keys -    23.00 cycles/hash
-Small key speed test -    5-byte keys -    27.00 cycles/hash
-Small key speed test -    6-byte keys -    31.00 cycles/hash
-Small key speed test -    7-byte keys -    35.00 cycles/hash
-Small key speed test -    8-byte keys -    39.00 cycles/hash
-Small key speed test -    9-byte keys -    43.00 cycles/hash
-Small key speed test -   10-byte keys -    47.00 cycles/hash
-Small key speed test -   11-byte keys -    51.00 cycles/hash
-Small key speed test -   12-byte keys -    55.00 cycles/hash
-Small key speed test -   13-byte keys -    59.00 cycles/hash
-Small key speed test -   14-byte keys -    63.00 cycles/hash
-Small key speed test -   15-byte keys -    67.00 cycles/hash
-Small key speed test -   16-byte keys -    71.00 cycles/hash
-Small key speed test -   17-byte keys -    75.00 cycles/hash
-Small key speed test -   18-byte keys -    79.00 cycles/hash
-Small key speed test -   19-byte keys -    83.00 cycles/hash
-Small key speed test -   20-byte keys -    87.00 cycles/hash
-Small key speed test -   21-byte keys -    91.00 cycles/hash
-Small key speed test -   22-byte keys -    95.00 cycles/hash
-Small key speed test -   23-byte keys -    99.00 cycles/hash
-Small key speed test -   24-byte keys -   103.00 cycles/hash
-Small key speed test -   25-byte keys -   107.00 cycles/hash
-Small key speed test -   26-byte keys -   111.00 cycles/hash
-Small key speed test -   27-byte keys -   115.00 cycles/hash
-Small key speed test -   28-byte keys -   119.00 cycles/hash
-Small key speed test -   29-byte keys -   123.00 cycles/hash
-Small key speed test -   30-byte keys -   127.00 cycles/hash
-Small key speed test -   31-byte keys -   131.00 cycles/hash
-Average                                    71.097 cycles/hash
+Small key speed test -    1-byte keys -    26.00 cycles/hash
+Small key speed test -    2-byte keys -    27.00 cycles/hash
+Small key speed test -    3-byte keys -    27.00 cycles/hash
+Small key speed test -    4-byte keys -    28.00 cycles/hash
+Small key speed test -    5-byte keys -    39.00 cycles/hash
+Small key speed test -    6-byte keys -    39.00 cycles/hash
+Small key speed test -    7-byte keys -    39.00 cycles/hash
+Small key speed test -    8-byte keys -    46.00 cycles/hash
+Small key speed test -    9-byte keys -    46.00 cycles/hash
+Small key speed test -   10-byte keys -    46.00 cycles/hash
+Small key speed test -   11-byte keys -    46.00 cycles/hash
+Small key speed test -   12-byte keys -    45.00 cycles/hash
+Small key speed test -   13-byte keys -    45.00 cycles/hash
+Small key speed test -   14-byte keys -    45.00 cycles/hash
+Small key speed test -   15-byte keys -    45.00 cycles/hash
+Small key speed test -   16-byte keys -    45.00 cycles/hash
+Small key speed test -   17-byte keys -    46.88 cycles/hash
+Small key speed test -   18-byte keys -    46.85 cycles/hash
+Small key speed test -   19-byte keys -    46.89 cycles/hash
+Small key speed test -   20-byte keys -    46.87 cycles/hash
+Small key speed test -   21-byte keys -    46.91 cycles/hash
+Small key speed test -   22-byte keys -    46.93 cycles/hash
+Small key speed test -   23-byte keys -    46.92 cycles/hash
+Small key speed test -   24-byte keys -    46.00 cycles/hash
+Small key speed test -   25-byte keys -    46.81 cycles/hash
+Small key speed test -   26-byte keys -    46.90 cycles/hash
+Small key speed test -   27-byte keys -    46.92 cycles/hash
+Small key speed test -   28-byte keys -    46.97 cycles/hash
+Small key speed test -   29-byte keys -    46.93 cycles/hash
+Small key speed test -   30-byte keys -    46.91 cycles/hash
+Small key speed test -   31-byte keys -    46.93 cycles/hash
+Average                                    43.116 cycles/hash
 
 [[[ Avalanche Tests ]]]
 
-Testing  32-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  40-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  48-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  56-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  64-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  72-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  80-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  96-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 112-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 128-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 160-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 192-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 224-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 256-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 320-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 384-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 448-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 512-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 640-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 768-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 896-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 1024-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 1280-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 1536-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing  32-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.666667%
+Testing  40-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 2.370667% !!!!! 
+Testing  48-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 1.018000% !!!!! 
+Testing  56-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.875333%
+Testing  64-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.631333%
+Testing  72-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.708000%
+Testing  80-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.729333%
+Testing  96-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.674000%
+Testing 112-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.748667%
+Testing 128-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.691333%
+Testing 160-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.742000%
+Testing 192-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.988667%
+Testing 224-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 62.712667% !!!!! 
+Testing 256-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 62.916000% !!!!! 
+Testing 320-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.860667%
+Testing 384-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 62.577333% !!!!! 
+Testing 448-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 62.893333% !!!!! 
+Testing 512-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 62.939333% !!!!! 
+Testing 640-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 63.093333% !!!!! 
+Testing 768-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 62.828667% !!!!! 
+Testing 896-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.896000%
+Testing 1024-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.833333%
+Testing 1280-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.797333%
+Testing 1536-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.923333%
 *********FAIL*********
 
 [[[ Keyset 'Cyclic' Tests ]]]
 
 Keyset 'Cyclic' - 8 cycles of 8 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  61 - 94.451% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.034%
 
 Keyset 'Cyclic' - 8 cycles of 9 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  60 - 90.013% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.043%
 
 Keyset 'Cyclic' - 8 cycles of 10 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  58 - 94.441% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  15 - 0.040%
 
 Keyset 'Cyclic' - 8 cycles of 11 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  58 - 90.022% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit   5 - 0.048%
 
 Keyset 'Cyclic' - 8 cycles of 12 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  59 - 94.440% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  29 - 0.024%
 
 Keyset 'Cyclic' - 8 cycles of 16 bytes - 10000000 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  61 - 94.439% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.035%
 
 
 [[[ Keyset 'TwoBytes' Tests ]]]
 
 Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  24 - 99.837% !!!!! 
+Testing distribution - Worst bias is the  16-bit window at bit  31 - 0.142%
 
 Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 97.231% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  54 - 0.057%
 
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 85.555% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  48 - 0.013%
 
 Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 63.029% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.006%
 
 Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 39.568% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  54 - 0.004%
 
 Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 23.147% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.003%
 
 
 [[[ Keyset 'Sparse' Tests ]]]
 
 Keyset 'Sparse' - 32-bit keys with up to 6 bits set - 1149017 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  17-bit window at bit  24 - 98.113% !!!!! 
+Testing distribution - Worst bias is the  17-bit window at bit  19 - 0.102%
 
 Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  21 - 92.385% !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit  32 - 0.039%
 
 Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 77.736% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  56 - 0.015%
 
 Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  21 - 81.293% !!!!! 
+Testing distribution - Worst bias is the  18-bit window at bit  49 - 0.050%
 
 Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 70.864% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  62 - 0.061%
 
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 52.770% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 0.015%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  22 - 58.042% !!!!! 
+Testing distribution - Worst bias is the  18-bit window at bit   7 - 0.054%
 
 Keyset 'Sparse' - 112-bit keys with up to 4 bits set - 6445069 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 47.616% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  35 - 0.051%
 
 Keyset 'Sparse' - 128-bit keys with up to 4 bits set - 11017633 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 30.774% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.033%
 
 Keyset 'Sparse' - 144-bit keys with up to 4 bits set - 17676661 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 19.131% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  19 - 0.013%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  48 - 17.921% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  56 - 0.010%
 
 Keyset 'Sparse' - 192-bit keys with up to 4 bits set - 56050289 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  48 - 17.548% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  61 - 0.006%
 
 Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  49 - 33.633% !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit   8 - 0.069%
 
 Keyset 'Sparse' - 288-bit keys with up to 3 bits set - 3981553 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  19-bit window at bit  50 - 33.207% !!!!! 
+Testing distribution - Worst bias is the  18-bit window at bit   6 - 0.062%
 
 Keyset 'Sparse' - 320-bit keys with up to 3 bits set - 5461601 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  49 - 33.614% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.060%
 
 Keyset 'Sparse' - 384-bit keys with up to 3 bits set - 9437505 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  49 - 33.703% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.028%
 
 Keyset 'Sparse' - 448-bit keys with up to 3 bits set - 14986273 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  49 - 33.269% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  11 - 0.022%
 
 Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  49 - 33.096% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  34 - 0.015%
 
 Keyset 'Sparse' - 640-bit keys with up to 3 bits set - 43691201 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  49 - 32.932% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  10 - 0.006%
 
 Keyset 'Sparse' - 768-bit keys with up to 3 bits set - 75498113 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  49 - 32.895% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  19 - 0.003%
 
 Keyset 'Sparse' - 896-bit keys with up to 2 bits set - 401857 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  57 - 56.963% !!!!! 
+Testing distribution - Worst bias is the  16-bit window at bit  62 - 0.241%
 
 Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  57 - 56.914% !!!!! 
+Testing distribution - Worst bias is the  16-bit window at bit  58 - 0.161%
 
 Keyset 'Sparse' - 1280-bit keys with up to 2 bits set - 819841 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  15-bit window at bit  60 - 56.909% !!!!! 
+Testing distribution - Worst bias is the  17-bit window at bit  10 - 0.166%
 
 Keyset 'Sparse' - 1536-bit keys with up to 2 bits set - 1180417 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  59 - 56.935% !!!!! 
+Testing distribution - Worst bias is the  17-bit window at bit  14 - 0.079%
 
 Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  18-bit window at bit  59 - 56.979% !!!!! 
+Testing distribution - Worst bias is the  18-bit window at bit  58 - 0.075%
 
 Keyset 'Sparse' - 3072-bit keys with up to 2 bits set - 4720129 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  15-bit window at bit   0 - 57.033% !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit  51 - 0.063%
 
 Keyset 'Sparse' - 4096-bit keys with up to 2 bits set - 8390657 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  15-bit window at bit   0 - 57.063% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.054%
 
 Keyset 'Sparse' - 6144-bit keys with up to 2 bits set - 18877441 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  15-bit window at bit   0 - 57.099% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit   5 - 0.014%
 
 Keyset 'Sparse' - 8192-bit keys with up to 2 bits set - 33558529 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  17-bit window at bit  62 - 57.112% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  55 - 0.008%
 
 Keyset 'Sparse' - 9992-bit keys with up to 2 bits set - 49925029 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  59 - 57.121% !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit  17 - 0.005%
 
 
 [[[ Keyset 'Combination Lowbits' Tests ]]]
 
 Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  58 - 50.250% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit   0 - 0.014%
 
 
 [[[ Keyset 'Combination Highbits' Tests ]]]
 
 Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  57 - 96.728% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  61 - 0.016%
 
 
 [[[ Keyset 'Combination 0x8000000' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  15-bit window at bit   0 - 99.550% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  33 - 0.016%
 
 
 [[[ Keyset 'Combination 0x0000001' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  54 - 89.239% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.012%
 
 
 [[[ Keyset 'Combination 0x800000000000000' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  63 - 99.485% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  55 - 0.023%
 
 
 [[[ Keyset 'Combination 0x000000000000001' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  18-bit window at bit  63 - 96.634% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  31 - 0.026%
 
 
 [[[ Keyset 'Combination 16-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   0 - 99.089% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.014%
 
 
 [[[ Keyset 'Combination 16-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   0 - 99.749% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  36 - 0.019%
 
 
 [[[ Keyset 'Combination 32-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   1 - 99.865% !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit  55 - 0.019%
 
 
 [[[ Keyset 'Combination 32-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   0 - 99.848% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  33 - 0.024%
 
 
 [[[ Keyset 'Combination 64-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit   0 - 99.925% !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit  32 - 0.012%
 
 
 [[[ Keyset 'Combination 64-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   0 - 99.995% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  57 - 0.017%
 
 
 [[[ Keyset 'Combination 128-bytes [0-1]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  18-bit window at bit   0 - 99.981% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  62 - 0.015%
 
 
 [[[ Keyset 'Combination 128-bytes [0-last]' Tests ]]]
 
 Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
-Testing collisions   - Expected     0.00, actual 36348.00 (4764206475.84x) !!!!! 
-Testing distribution - Worst bias is the  20-bit window at bit   0 - 99.995% !!!!! 
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  29 - 0.025%
 
-*********FAIL*********
 
 [[[ Keyset 'Combination Hi-Lo' Tests ]]]
 
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  49 - 56.079% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  53 - 0.034%
 
 
 [[[ Keyset 'Window' Tests ]]]
@@ -509,30 +508,31 @@ Window at 136 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00
 
 Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  46 - 3.146% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  11 - 0.022%
 
 Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit  20 - 95.545% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  25 - 0.017%
 
 Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  20-bit window at bit   7 - 1.472% !!!!! 
+Testing distribution - Worst bias is the  20-bit window at bit  41 - 0.033%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
 
 Keyset 'Zeroes' - 204800 keys
 Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  15-bit window at bit  53 - 75.021% !!!!! 
+Testing distribution - Worst bias is the  15-bit window at bit  61 - 0.217%
 
 
 [[[ Keyset 'Seed' Tests ]]]
 
 Keyset 'Seed' - 5000000 keys
-Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  16-bit window at bit  55 - 58.086% !!!!! 
+Testing collisions   - Expected     0.00, actual 4999999.00 (7378697629483.82x) !!!!! 
+Testing distribution - Worst bias is the  19-bit window at bit   0 - 100.000% !!!!! 
 
+*********FAIL*********
 
 [[[ Differential Tests ]]]
 
@@ -551,5 +551,5 @@ Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 64 bit hashes.
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took -1565.137346 seconds
+Verification value is 0x00000001 - Testing took 2131.903288 seconds
 -------------------------------------------------------------------------------

--- a/doc/FarmHash64noSeed
+++ b/doc/FarmHash64noSeed
@@ -1,5 +1,0 @@
-Invalid hash 'FarmHash64noSeed' specified
-
-Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 0.000010 seconds
--------------------------------------------------------------------------------

--- a/doc/FarmHash64noSeed
+++ b/doc/FarmHash64noSeed
@@ -1,0 +1,5 @@
+Invalid hash 'FarmHash64noSeed' specified
+
+Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
+Verification value is 0x00000001 - Testing took 0.000010 seconds
+-------------------------------------------------------------------------------

--- a/doc/crc32
+++ b/doc/crc32
@@ -1,4 +1,4 @@
-
+-------------------------------------------------------------------------------
 --- Testing crc32 "CRC-32 soft"
 
 [[[ Sanity Tests ]]]
@@ -10,63 +10,48 @@ Running AppendedZeroesTest..........PASS
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  0.199 bytes/cycle -  569.69 MiB/sec @ 3 ghz
-Alignment  6 -  0.199 bytes/cycle -  569.68 MiB/sec @ 3 ghz
-Alignment  5 -  0.199 bytes/cycle -  569.75 MiB/sec @ 3 ghz
-Alignment  4 -  0.199 bytes/cycle -  569.71 MiB/sec @ 3 ghz
-Alignment  3 -  0.199 bytes/cycle -  569.72 MiB/sec @ 3 ghz
-Alignment  2 -  0.199 bytes/cycle -  569.65 MiB/sec @ 3 ghz
-Alignment  1 -  0.199 bytes/cycle -  569.69 MiB/sec @ 3 ghz
-Alignment  0 -  0.199 bytes/cycle -  569.79 MiB/sec @ 3 ghz
-Average      -  0.199 bytes/cycle -  569.71 MiB/sec @ 3 ghz
+Alignment  7 -  0.124 bytes/cycle -  355.59 MiB/sec @ 3 ghz
+Alignment  6 -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
+Alignment  5 -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
+Alignment  4 -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
+Alignment  3 -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
+Alignment  2 -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
+Alignment  1 -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
+Alignment  0 -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
+Average      -  0.124 bytes/cycle -  355.62 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    14.76 cycles/hash
-Small key speed test -    2-byte keys -    19.96 cycles/hash
-Small key speed test -    3-byte keys -    24.00 cycles/hash
-Small key speed test -    4-byte keys -    30.00 cycles/hash
-Small key speed test -    5-byte keys -    35.00 cycles/hash
-Small key speed test -    6-byte keys -    40.00 cycles/hash
-Small key speed test -    7-byte keys -    45.00 cycles/hash
-Small key speed test -    8-byte keys -    50.00 cycles/hash
-Small key speed test -    9-byte keys -    55.00 cycles/hash
-Small key speed test -   10-byte keys -    60.00 cycles/hash
-Small key speed test -   11-byte keys -    81.00 cycles/hash
-Small key speed test -   12-byte keys -    70.00 cycles/hash
-Small key speed test -   13-byte keys -    75.98 cycles/hash
-Small key speed test -   14-byte keys -    80.00 cycles/hash
-Small key speed test -   15-byte keys -    85.00 cycles/hash
-Small key speed test -   16-byte keys -    90.00 cycles/hash
-Small key speed test -   17-byte keys -   119.50 cycles/hash
-Small key speed test -   18-byte keys -   100.00 cycles/hash
-Small key speed test -   19-byte keys -   105.00 cycles/hash
-Small key speed test -   20-byte keys -   110.00 cycles/hash
-Small key speed test -   21-byte keys -   115.00 cycles/hash
-Small key speed test -   22-byte keys -   120.00 cycles/hash
-Small key speed test -   23-byte keys -   152.76 cycles/hash
-Small key speed test -   24-byte keys -   130.00 cycles/hash
-Small key speed test -   25-byte keys -   135.00 cycles/hash
-Small key speed test -   26-byte keys -   140.70 cycles/hash
-Small key speed test -   27-byte keys -   181.69 cycles/hash
-Small key speed test -   28-byte keys -   150.89 cycles/hash
-Small key speed test -   29-byte keys -   201.21 cycles/hash
-Small key speed test -   30-byte keys -   201.96 cycles/hash
-Small key speed test -   31-byte keys -   208.51 cycles/hash
-Average                                    97.675 cycles/hash
-
-[[[ Differential Tests ]]]
-
-Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
-1000 reps, 8303632000 total tests, expecting 1.93 random collisions..........
-0 total collisions, of which 0 single collisions were ignored
-
-Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 32 bit hashes.
-1000 reps, 11017632000 total tests, expecting 2.57 random collisions..........
-0 total collisions, of which 0 single collisions were ignored
-
-Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 32 bit hashes.
-1000 reps, 2796416000 total tests, expecting 0.65 random collisions..........
-0 total collisions, of which 0 single collisions were ignored
-
+Small key speed test -    1-byte keys -    16.00 cycles/hash
+Small key speed test -    2-byte keys -    24.00 cycles/hash
+Small key speed test -    3-byte keys -    32.00 cycles/hash
+Small key speed test -    4-byte keys -    40.00 cycles/hash
+Small key speed test -    5-byte keys -    48.00 cycles/hash
+Small key speed test -    6-byte keys -    56.00 cycles/hash
+Small key speed test -    7-byte keys -    64.00 cycles/hash
+Small key speed test -    8-byte keys -    72.00 cycles/hash
+Small key speed test -    9-byte keys -    80.52 cycles/hash
+Small key speed test -   10-byte keys -    88.96 cycles/hash
+Small key speed test -   11-byte keys -    96.82 cycles/hash
+Small key speed test -   12-byte keys -   104.99 cycles/hash
+Small key speed test -   13-byte keys -   113.00 cycles/hash
+Small key speed test -   14-byte keys -   121.00 cycles/hash
+Small key speed test -   15-byte keys -   129.00 cycles/hash
+Small key speed test -   16-byte keys -   137.00 cycles/hash
+Small key speed test -   17-byte keys -   145.00 cycles/hash
+Small key speed test -   18-byte keys -   153.00 cycles/hash
+Small key speed test -   19-byte keys -   161.00 cycles/hash
+Small key speed test -   20-byte keys -   169.00 cycles/hash
+Small key speed test -   21-byte keys -   177.00 cycles/hash
+Small key speed test -   22-byte keys -   185.00 cycles/hash
+Small key speed test -   23-byte keys -   193.00 cycles/hash
+Small key speed test -   24-byte keys -   201.00 cycles/hash
+Small key speed test -   25-byte keys -   209.00 cycles/hash
+Small key speed test -   26-byte keys -   217.00 cycles/hash
+Small key speed test -   27-byte keys -   225.00 cycles/hash
+Small key speed test -   28-byte keys -   233.00 cycles/hash
+Small key speed test -   29-byte keys -   241.00 cycles/hash
+Small key speed test -   30-byte keys -   249.31 cycles/hash
+Small key speed test -   31-byte keys -   257.80 cycles/hash
+Average                                    136.755 cycles/hash
 
 [[[ Avalanche Tests ]]]
 
@@ -77,15 +62,23 @@ Testing  56-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 10
 Testing  64-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
 Testing  72-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
 Testing  80-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing  88-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
 Testing  96-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 104-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
 Testing 112-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 120-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
 Testing 128-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 136-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 144-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
-Testing 152-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 160-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 192-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 224-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 256-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 320-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 384-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 448-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 512-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 640-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 768-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 896-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 1024-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 1280-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
+Testing 1536-bit keys ->  32-bit hashes,   300000 reps.......... worst bias is 100.000000% !!!!! 
 *********FAIL*********
 
 [[[ Keyset 'Cyclic' Tests ]]]
@@ -110,6 +103,10 @@ Keyset 'Cyclic' - 8 cycles of 8 bytes - 10000000 keys
 Testing collisions   - Expected 11641.53, actual 11653.00 ( 1.00x)
 Testing distribution - Worst bias is the  20-bit window at bit  27 - 0.026%
 
+Keyset 'Cyclic' - 8 cycles of 12 bytes - 10000000 keys
+Testing collisions   - Expected 11641.53, actual 11768.00 ( 1.01x)
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.030%
+
 
 [[[ Keyset 'TwoBytes' Tests ]]]
 
@@ -133,6 +130,10 @@ Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 Testing collisions   - Expected 871784.70, actual 945584.00 ( 1.08x)
 Testing distribution - Worst bias is the  19-bit window at bit  16 - 0.091%
 
+Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
+Testing collisions   - Expected 2606569.03, actual 2676312.00 ( 1.03x)
+Testing distribution - Worst bias is the  19-bit window at bit  16 - 0.043%
+
 *********FAIL*********
 
 [[[ Keyset 'Sparse' Tests ]]]
@@ -145,9 +146,9 @@ Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
 Testing collisions   - Expected  2461.72, actual     0.00 ( 0.00x)
 Testing distribution - Worst bias is the  17-bit window at bit   5 - 1.313% !!!!! 
 
-Keyset 'Sparse' - 48-bit keys with up to 5 bits set - 1925357 keys
-Testing collisions   - Expected   431.55, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  18-bit window at bit   1 - 1.479% !!!!! 
+Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
+Testing collisions   - Expected 23463.63, actual 10164.00 ( 0.43x)
+Testing distribution - Worst bias is the  20-bit window at bit   1 - 0.285%
 
 Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
 Testing collisions   - Expected  2069.66, actual   378.00 ( 0.18x)
@@ -157,17 +158,105 @@ Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
 Testing collisions   - Expected  8026.87, actual  3654.00 ( 0.46x)
 Testing distribution - Worst bias is the  20-bit window at bit  17 - 3.685% !!!!! 
 
+Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
+Testing collisions   - Expected 26482.73, actual 13355.00 ( 0.50x)
+Testing distribution - Worst bias is the  20-bit window at bit  16 - 1.044% !!!!! 
+
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
 Testing collisions   - Expected  1401.34, actual   245.00 ( 0.17x)
 Testing distribution - Worst bias is the  17-bit window at bit  30 - 0.313%
+
+Keyset 'Sparse' - 112-bit keys with up to 4 bits set - 6445069 keys
+Testing collisions   - Expected  4835.77, actual  2751.00 ( 0.57x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.837%
+
+Keyset 'Sparse' - 128-bit keys with up to 4 bits set - 11017633 keys
+Testing collisions   - Expected 14131.45, actual 12729.00 ( 0.90x)
+Testing distribution - Worst bias is the  20-bit window at bit  22 - 0.212%
+
+Keyset 'Sparse' - 144-bit keys with up to 4 bits set - 17676661 keys
+Testing collisions   - Expected 36375.64, actual 37177.00 ( 1.02x)
+Testing distribution - Worst bias is the  17-bit window at bit  30 - 0.060%
+
+Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
+Testing collisions   - Expected 84723.25, actual 87795.00 ( 1.04x)
+Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.134%
+
+Keyset 'Sparse' - 192-bit keys with up to 4 bits set - 56050289 keys
+Testing collisions   - Expected 365734.43, actual 356287.00 ( 0.97x)
+Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.093%
 
 Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
 Testing collisions   - Expected   910.36, actual   970.00 ( 1.07x)
 Testing distribution - Worst bias is the  17-bit window at bit  30 - 0.229%
 
+Keyset 'Sparse' - 288-bit keys with up to 3 bits set - 3981553 keys
+Testing collisions   - Expected  1845.50, actual  2747.00 ( 1.49x)
+Testing distribution - Worst bias is the  19-bit window at bit   6 - 0.211%
+
+Keyset 'Sparse' - 320-bit keys with up to 3 bits set - 5461601 keys
+Testing collisions   - Expected  3472.56, actual  5405.00 ( 1.56x)
+Testing distribution - Worst bias is the  20-bit window at bit   7 - 0.358%
+
+Keyset 'Sparse' - 384-bit keys with up to 3 bits set - 9437505 keys
+Testing collisions   - Expected 10368.70, actual 14191.00 ( 1.37x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.254%
+
+Keyset 'Sparse' - 448-bit keys with up to 3 bits set - 14986273 keys
+Testing collisions   - Expected 26145.53, actual 31591.00 ( 1.21x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.076%
+
+Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
+Testing collisions   - Expected 58256.45, actual 68433.00 ( 1.17x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.014%
+
+Keyset 'Sparse' - 640-bit keys with up to 3 bits set - 43691201 keys
+Testing collisions   - Expected 222227.65, actual 232013.00 ( 1.04x)
+Testing distribution - Worst bias is the  20-bit window at bit   7 - 0.020%
+
+Keyset 'Sparse' - 768-bit keys with up to 3 bits set - 75498113 keys
+Testing collisions   - Expected 663563.26, actual 660836.00 ( 1.00x)
+Testing distribution - Worst bias is the  16-bit window at bit  29 - 0.003%
+
+Keyset 'Sparse' - 896-bit keys with up to 2 bits set - 401857 keys
+Testing collisions   - Expected    18.80, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  16-bit window at bit  10 - 0.334%
+
+Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
+Testing collisions   - Expected    32.06, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  16-bit window at bit   0 - 0.255%
+
+Keyset 'Sparse' - 1280-bit keys with up to 2 bits set - 819841 keys
+Testing collisions   - Expected    78.25, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  17-bit window at bit   0 - 0.174%
+
+Keyset 'Sparse' - 1536-bit keys with up to 2 bits set - 1180417 keys
+Testing collisions   - Expected   162.21, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  17-bit window at bit  13 - 0.108%
+
 Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
 Testing collisions   - Expected   512.50, actual     0.00 ( 0.00x)
 Testing distribution - Worst bias is the  16-bit window at bit  10 - 0.124%
+
+Keyset 'Sparse' - 3072-bit keys with up to 2 bits set - 4720129 keys
+Testing collisions   - Expected  2593.69, actual   198.00 ( 0.08x)
+Testing distribution - Worst bias is the  15-bit window at bit  11 - 0.030%
+
+Keyset 'Sparse' - 4096-bit keys with up to 2 bits set - 8390657 keys
+Testing collisions   - Expected  8196.00, actual  3504.00 ( 0.43x)
+Testing distribution - Worst bias is the  15-bit window at bit  11 - 0.009%
+
+Keyset 'Sparse' - 6144-bit keys with up to 2 bits set - 18877441 keys
+Testing collisions   - Expected 41485.50, actual 32124.00 ( 0.77x)
+Testing distribution - Worst bias is the  16-bit window at bit  10 - 0.005%
+
+Keyset 'Sparse' - 8192-bit keys with up to 2 bits set - 33558529 keys
+Testing collisions   - Expected 131104.01, actual 142887.00 ( 1.09x)
+Testing distribution - Worst bias is the  19-bit window at bit   7 - 0.014%
+
+Keyset 'Sparse' - 9992-bit keys with up to 2 bits set - 49925029 keys
+Testing collisions   - Expected 290166.18, actual 314519.00 ( 1.08x)
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.019%
 
 
 [[[ Keyset 'Combination Lowbits' Tests ]]]
@@ -186,16 +275,86 @@ Testing distribution - Worst bias is the  19-bit window at bit  22 - 47.707% !!!
 
 [[[ Keyset 'Combination 0x8000000' Tests ]]]
 
-Keyset 'Combination' - up to 20 blocks from a set of 2 - 2097150 keys
-Testing collisions   - Expected   512.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  18-bit window at bit  22 - 45.368% !!!!! 
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 42.131% !!!!! 
 
 
 [[[ Keyset 'Combination 0x0000001' Tests ]]]
 
-Keyset 'Combination' - up to 20 blocks from a set of 2 - 2097150 keys
-Testing collisions   - Expected   512.00, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  17-bit window at bit  20 - 45.553% !!!!! 
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  18 - 42.970% !!!!! 
+
+
+[[[ Keyset 'Combination 0x800000000000000' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   6 - 43.022% !!!!! 
+
+
+[[[ Keyset 'Combination 0x000000000000001' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   7 - 8.843% !!!!! 
+
+
+[[[ Keyset 'Combination 16-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  18 - 38.234% !!!!! 
+
+
+[[[ Keyset 'Combination 16-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  24 - 17.728% !!!!! 
+
+
+[[[ Keyset 'Combination 32-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  27 - 16.584% !!!!! 
+
+
+[[[ Keyset 'Combination 32-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  23 - 37.943% !!!!! 
+
+
+[[[ Keyset 'Combination 64-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  31 - 37.552% !!!!! 
+
+
+[[[ Keyset 'Combination 64-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  15-bit window at bit  21 - 1.857% !!!!! 
+
+
+[[[ Keyset 'Combination 128-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     2.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 42.490% !!!!! 
+
+
+[[[ Keyset 'Combination 128-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected 32767.99, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  18-bit window at bit   8 - 30.109% !!!!! 
 
 
 [[[ Keyset 'Combination Hi-Lo' Tests ]]]
@@ -207,7 +366,7 @@ Testing distribution - Worst bias is the  20-bit window at bit   3 - 4.132% !!!!
 
 [[[ Keyset 'Window' Tests ]]]
 
-Keyset 'Windowed' -  64-bit key,  20-bit window - 64 tests, 1048576 keys per test
+Keyset 'Windowed' -  72-bit key,  20-bit window - 72 tests, 1048576 keys per test
 Window at   0 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
 Window at   1 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
 Window at   2 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
@@ -273,6 +432,14 @@ Window at  61 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00
 Window at  62 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
 Window at  63 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
 Window at  64 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  65 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  66 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  67 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  68 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  69 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  70 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  71 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
+Window at  72 - Testing collisions   - Expected   128.00, actual     0.00 ( 0.00x)
 
 [[[ Keyset 'Text' Tests ]]]
 
@@ -291,18 +458,34 @@ Testing distribution - Worst bias is the  20-bit window at bit  13 - 30.061% !!!
 
 [[[ Keyset 'Zeroes' Tests ]]]
 
-Keyset 'Zeroes' - 65536 keys
-Testing collisions   - Expected     0.50, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  13-bit window at bit  14 - 0.400%
+Keyset 'Zeroes' - 204800 keys
+Testing collisions   - Expected     4.88, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  15-bit window at bit   4 - 0.150%
 
 
 [[[ Keyset 'Seed' Tests ]]]
 
-Keyset 'Seed' - 1000000 keys
-Testing collisions   - Expected   116.42, actual     0.00 ( 0.00x)
-Testing distribution - Worst bias is the  -1-bit window at bit  -1 - 0.000%
+Keyset 'Seed' - 5000000 keys
+Testing collisions   - Expected  2910.38, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit   0 - 26.190% !!!!! 
+
+
+[[[ Differential Tests ]]]
+
+Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
+1000 reps, 8303632000 total tests, expecting 1.93 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
+
+Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 32 bit hashes.
+1000 reps, 11017632000 total tests, expecting 2.57 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
+
+Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 32 bit hashes.
+1000 reps, 2796416000 total tests, expecting 0.65 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
 
 
 
-Input vcode 0x23457975, Output vcode 0xb8217222, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 2111.055408 seconds
+Input vcode 0x14b1fa0c, Output vcode 0x3249d674, Result vcode 0x00000001
+Verification value is 0x00000001 - Testing took 352.485867 seconds
+-------------------------------------------------------------------------------

--- a/doc/xxh3
+++ b/doc/xxh3
@@ -1,0 +1,562 @@
+-------------------------------------------------------------------------------
+--- Testing xxh3 "xxHash v3, 64-bit"
+
+[[[ Sanity Tests ]]]
+
+Verification value 0xF6FED399 : PASS
+Running sanity check 1    ..........PASS
+Running AppendedZeroesTest..........PASS
+
+[[[ Speed Tests ]]]
+
+Bulk speed test - 262144-byte keys
+Alignment  7 - 16.111 bytes/cycle - 46094.89 MiB/sec @ 3 ghz
+Alignment  6 - 16.719 bytes/cycle - 47832.97 MiB/sec @ 3 ghz
+Alignment  5 - 16.608 bytes/cycle - 47514.84 MiB/sec @ 3 ghz
+Alignment  4 - 17.020 bytes/cycle - 48694.95 MiB/sec @ 3 ghz
+Alignment  3 - 15.800 bytes/cycle - 45204.45 MiB/sec @ 3 ghz
+Alignment  2 - 16.596 bytes/cycle - 47481.61 MiB/sec @ 3 ghz
+Alignment  1 - 16.665 bytes/cycle - 47677.98 MiB/sec @ 3 ghz
+Alignment  0 - 18.058 bytes/cycle - 51664.09 MiB/sec @ 3 ghz
+Average      - 16.697 bytes/cycle - 47770.72 MiB/sec @ 3 ghz
+
+Small key speed test -    1-byte keys -    13.69 cycles/hash
+Small key speed test -    2-byte keys -    13.87 cycles/hash
+Small key speed test -    3-byte keys -    14.22 cycles/hash
+Small key speed test -    4-byte keys -    12.61 cycles/hash
+Small key speed test -    5-byte keys -    18.00 cycles/hash
+Small key speed test -    6-byte keys -    19.09 cycles/hash
+Small key speed test -    7-byte keys -    18.94 cycles/hash
+Small key speed test -    8-byte keys -    11.66 cycles/hash
+Small key speed test -    9-byte keys -    20.00 cycles/hash
+Small key speed test -   10-byte keys -    20.00 cycles/hash
+Small key speed test -   11-byte keys -    20.91 cycles/hash
+Small key speed test -   12-byte keys -    19.00 cycles/hash
+Small key speed test -   13-byte keys -    19.00 cycles/hash
+Small key speed test -   14-byte keys -    19.00 cycles/hash
+Small key speed test -   15-byte keys -    19.31 cycles/hash
+Small key speed test -   16-byte keys -    19.00 cycles/hash
+Small key speed test -   17-byte keys -    22.08 cycles/hash
+Small key speed test -   18-byte keys -    22.52 cycles/hash
+Small key speed test -   19-byte keys -    21.00 cycles/hash
+Small key speed test -   20-byte keys -    20.00 cycles/hash
+Small key speed test -   21-byte keys -    20.45 cycles/hash
+Small key speed test -   22-byte keys -    20.52 cycles/hash
+Small key speed test -   23-byte keys -    21.11 cycles/hash
+Small key speed test -   24-byte keys -    20.00 cycles/hash
+Small key speed test -   25-byte keys -    20.00 cycles/hash
+Small key speed test -   26-byte keys -    20.67 cycles/hash
+Small key speed test -   27-byte keys -    20.00 cycles/hash
+Small key speed test -   28-byte keys -    20.83 cycles/hash
+Small key speed test -   29-byte keys -    21.16 cycles/hash
+Small key speed test -   30-byte keys -    20.41 cycles/hash
+Small key speed test -   31-byte keys -    21.13 cycles/hash
+Average                                    19.038 cycles/hash
+
+[[[ Avalanche Tests ]]]
+
+Testing  24-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.617333%
+Testing  32-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.725333%
+Testing  40-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.662667%
+Testing  48-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.633333%
+Testing  56-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.743333%
+Testing  64-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.680000%
+Testing  72-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.582000%
+Testing  80-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.635333%
+Testing  96-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.672667%
+Testing 112-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.716000%
+Testing 128-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.694000%
+Testing 160-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.778000%
+Testing 192-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.712000%
+Testing 224-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.732667%
+Testing 256-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.710667%
+Testing 320-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.766667%
+Testing 384-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.774000%
+Testing 448-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.773333%
+Testing 512-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.811333%
+Testing 640-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.786000%
+Testing 768-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.750667%
+Testing 896-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.764000%
+Testing 1024-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.885333%
+Testing 1280-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.792667%
+Testing 1536-bit keys ->  64-bit hashes,   300000 reps.......... worst bias is 0.914000%
+
+[[[ Keyset 'Sparse' Tests ]]]
+
+Keyset 'Sparse' - 16-bit keys with up to 9 bits set - 50643 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  13-bit window at bit   7 - 0.560%
+
+Keyset 'Sparse' - 24-bit keys with up to 8 bits set - 1271626 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  17-bit window at bit  21 - 0.095%
+
+Keyset 'Sparse' - 32-bit keys with up to 7 bits set - 4514873 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  15 - 0.042%
+
+Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  59 - 0.045%
+
+Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  12 - 0.022%
+
+Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  16 - 0.049%
+
+Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.041%
+
+Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  28 - 0.019%
+
+Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  14 - 0.061%
+
+Keyset 'Sparse' - 112-bit keys with up to 4 bits set - 6445069 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  32 - 0.058%
+
+Keyset 'Sparse' - 128-bit keys with up to 4 bits set - 11017633 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  30 - 0.018%
+
+Keyset 'Sparse' - 144-bit keys with up to 4 bits set - 17676661 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  32 - 0.028%
+
+Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  51 - 0.014%
+
+Keyset 'Sparse' - 192-bit keys with up to 4 bits set - 56050289 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.006%
+
+Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  42 - 0.099%
+
+Keyset 'Sparse' - 288-bit keys with up to 3 bits set - 3981553 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  45 - 0.042%
+
+Keyset 'Sparse' - 320-bit keys with up to 3 bits set - 5461601 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   3 - 0.041%
+
+Keyset 'Sparse' - 384-bit keys with up to 3 bits set - 9437505 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  51 - 0.035%
+
+Keyset 'Sparse' - 448-bit keys with up to 3 bits set - 14986273 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  16 - 0.017%
+
+Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  41 - 0.017%
+
+Keyset 'Sparse' - 640-bit keys with up to 3 bits set - 43691201 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   6 - 0.009%
+
+Keyset 'Sparse' - 768-bit keys with up to 3 bits set - 75498113 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  51 - 0.004%
+
+Keyset 'Sparse' - 896-bit keys with up to 2 bits set - 401857 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  16-bit window at bit  47 - 0.124%
+
+Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  16-bit window at bit  41 - 0.179%
+
+Keyset 'Sparse' - 1280-bit keys with up to 2 bits set - 819841 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  17-bit window at bit  36 - 0.154%
+
+Keyset 'Sparse' - 1536-bit keys with up to 2 bits set - 1180417 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  17-bit window at bit  44 - 0.089%
+
+Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  18-bit window at bit  54 - 0.111%
+
+Keyset 'Sparse' - 3072-bit keys with up to 2 bits set - 4720129 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  18-bit window at bit  50 - 0.046%
+
+Keyset 'Sparse' - 4096-bit keys with up to 2 bits set - 8390657 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  62 - 0.027%
+
+Keyset 'Sparse' - 6144-bit keys with up to 2 bits set - 18877441 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  49 - 0.022%
+
+Keyset 'Sparse' - 8192-bit keys with up to 2 bits set - 33558529 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  20 - 0.009%
+
+Keyset 'Sparse' - 9992-bit keys with up to 2 bits set - 49925029 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  35 - 0.007%
+
+
+[[[ Keyset 'Combination Lowbits' Tests ]]]
+
+Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  36 - 0.017%
+
+
+[[[ Keyset 'Combination Highbits' Tests ]]]
+
+Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  51 - 0.016%
+
+
+[[[ Keyset 'Combination Hi-Lo' Tests ]]]
+
+Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  13 - 0.042%
+
+
+[[[ Keyset 'Combination 0x8000000' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  41 - 0.018%
+
+
+[[[ Keyset 'Combination 0x0000001' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   4 - 0.015%
+
+
+[[[ Keyset 'Combination 0x800000000000000' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  45 - 0.030%
+
+
+[[[ Keyset 'Combination 0x000000000000001' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  56 - 0.014%
+
+
+[[[ Keyset 'Combination 16-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  26 - 0.018%
+
+
+[[[ Keyset 'Combination 16-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  39 - 0.018%
+
+
+[[[ Keyset 'Combination 32-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  22 - 0.016%
+
+
+[[[ Keyset 'Combination 32-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  18 - 0.021%
+
+
+[[[ Keyset 'Combination 64-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.020%
+
+
+[[[ Keyset 'Combination 64-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  41 - 0.023%
+
+
+[[[ Keyset 'Combination 128-bytes [0-1]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.021%
+
+
+[[[ Keyset 'Combination 128-bytes [0-last]' Tests ]]]
+
+Keyset 'Combination' - up to 23 blocks from a set of 2 - 16777214 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.016%
+
+
+[[[ Keyset 'Window' Tests ]]]
+
+Keyset 'Windowed' - 136-bit key,  20-bit window - 136 tests, 1048576 keys per test
+Window at   0 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   1 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   2 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   3 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   4 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   5 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   6 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   7 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   8 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at   9 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  10 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  11 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  12 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  13 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  14 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  15 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  16 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  17 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  18 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  19 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  20 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  21 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  22 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  23 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  24 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  25 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  26 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  27 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  28 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  29 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  30 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  31 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  32 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  33 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  34 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  35 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  36 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  37 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  38 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  39 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  40 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  41 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  42 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  43 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  44 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  45 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  46 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  47 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  48 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  49 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  50 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  51 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  52 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  53 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  54 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  55 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  56 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  57 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  58 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  59 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  60 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  61 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  62 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  63 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  64 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  65 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  66 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  67 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  68 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  69 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  70 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  71 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  72 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  73 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  74 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  75 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  76 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  77 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  78 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  79 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  80 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  81 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  82 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  83 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  84 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  85 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  86 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  87 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  88 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  89 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  90 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  91 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  92 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  93 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  94 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  95 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  96 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  97 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  98 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at  99 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 100 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 101 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 102 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 103 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 104 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 105 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 106 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 107 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 108 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 109 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 110 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 111 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 112 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 113 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 114 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 115 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 116 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 117 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 118 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 119 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 120 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 121 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 122 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 123 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 124 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 125 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 126 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 127 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 128 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 129 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 130 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 131 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 132 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 133 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 134 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 135 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Window at 136 - Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+
+[[[ Keyset 'Cyclic' Tests ]]]
+
+Keyset 'Cyclic' - 8 cycles of 8 bytes - 10000000 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  17 - 0.021%
+
+Keyset 'Cyclic' - 8 cycles of 9 bytes - 10000000 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  17 - 0.026%
+
+Keyset 'Cyclic' - 8 cycles of 10 bytes - 10000000 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  39 - 0.036%
+
+Keyset 'Cyclic' - 8 cycles of 11 bytes - 10000000 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  34 - 0.044%
+
+Keyset 'Cyclic' - 8 cycles of 12 bytes - 10000000 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  38 - 0.029%
+
+Keyset 'Cyclic' - 8 cycles of 16 bytes - 10000000 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  52 - 0.041%
+
+
+[[[ Keyset 'TwoBytes' Tests ]]]
+
+Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  16-bit window at bit  57 - 0.152%
+
+Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   8 - 0.068%
+
+Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.028%
+
+Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit   9 - 0.007%
+
+Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  23 - 0.005%
+
+Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  45 - 0.002%
+
+
+[[[ Keyset 'Text' Tests ]]]
+
+Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  44 - 0.025%
+
+Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  20-bit window at bit  21 - 0.023%
+
+Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  16 - 0.021%
+
+
+[[[ Keyset 'Zeroes' Tests ]]]
+
+Keyset 'Zeroes' - 204800 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  15-bit window at bit  18 - 0.242%
+
+
+[[[ Keyset 'Seed' Tests ]]]
+
+Keyset 'Seed' - 5000000 keys
+Testing collisions   - Expected     0.00, actual     0.00 ( 0.00x)
+Testing distribution - Worst bias is the  19-bit window at bit  49 - 0.054%
+
+
+[[[ Differential Tests ]]]
+
+Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 64 bit hashes.
+1000 reps, 8303632000 total tests, expecting 0.00 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
+
+Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 64 bit hashes.
+1000 reps, 11017632000 total tests, expecting 0.00 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
+
+Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 64 bit hashes.
+1000 reps, 2796416000 total tests, expecting 0.00 random collisions..........
+0 total collisions, of which 0 single collisions were ignored
+
+
+
+Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
+Verification value is 0x00000001 - Testing took 1813.048359 seconds
+-------------------------------------------------------------------------------

--- a/main.cpp
+++ b/main.cpp
@@ -341,6 +341,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
 
     bool result = true;
 
+    result &= AvalancheTest< Blob< 24>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob< 32>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob< 40>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob< 48>, hashtype > (hash,300000);
@@ -387,6 +388,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     bool result = true;
     bool drawDiagram = false;
 
+    result &= SparseKeyTest<  24,hashtype>(hash,7,true,true,true,drawDiagram);
     result &= SparseKeyTest<  32,hashtype>(hash,6,true,true,true,drawDiagram);
     result &= SparseKeyTest<  40,hashtype>(hash,6,true,true,true,drawDiagram);
     result &= SparseKeyTest<  48,hashtype>(hash,6,true,true,true,drawDiagram);
@@ -466,6 +468,28 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       };
 
       result &= CombinationKeyTest(hash,8,blocks,sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination Hi-Lo' Tests ]]]\n\n");
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      uint32_t blocks[] =
+      {
+        0x00000000,
+
+        0x00000001, 0x00000002, 0x00000003, 0x00000004, 0x00000005, 0x00000006, 0x00000007,
+
+        0x80000000, 0x40000000, 0xC0000000, 0x20000000, 0xA0000000, 0x60000000, 0xE0000000
+      };
+
+      result &= CombinationKeyTest<hashtype>(hash,6,blocks,sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
 
       if(!result) printf("*********FAIL*********\n");
       printf("\n");
@@ -703,27 +727,6 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
     }
 
-    {
-      printf("[[[ Keyset 'Combination Hi-Lo' Tests ]]]\n\n");
-
-      bool result = true;
-      bool drawDiagram = false;
-
-      uint32_t blocks[] =
-      {
-        0x00000000,
-
-        0x00000001, 0x00000002, 0x00000003, 0x00000004, 0x00000005, 0x00000006, 0x00000007,
-
-        0x80000000, 0x40000000, 0xC0000000, 0x20000000, 0xA0000000, 0x60000000, 0xE0000000
-      };
-
-      result &= CombinationKeyTest<hashtype>(hash,6,blocks,sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
-
-      if(!result) printf("*********FAIL*********\n");
-      printf("\n");
-      fflush(NULL);
-    }
   }
 
   //-----------------------------------------------------------------------------

--- a/main.cpp
+++ b/main.cpp
@@ -164,8 +164,12 @@ HashInfo g_hashes[] =
  #define MUM_SEED             0xA973C6C0
 #endif
   { mum_hash_test,        64, MUM_SEED,   "MUM",         "github.com/vnmakarov/mum-hash" },
+  { mum_low_test,         32, MUM_SEED,   "MUMlow",      "github.com/vnmakarov/mum-hash" },
+  { mum_high_test,        32, MUM_SEED,   "MUMhigh",     "github.com/vnmakarov/mum-hash" },
+
   { CityHash32_test,      32, 0x5C28AD62, "City32",      "Google CityHash32WithSeed (old)" },
   { CityHash64_test,      64, 0x25A20825, "City64",      "Google CityHash64WithSeed (old)" },
+  { CityHash64noSeed_test,64, 0x63FC6063, "City64noSeed","Google CityHash64 without seed (default version, misses one final avalanche)" },
 #if defined(__SSE4_2__) && defined(__x86_64__)
   { CityHash128_test,    128, 0x6531F54E, "City128",     "Google CityHash128WithSeed (old)" },
   { CityHashCrc128_test, 128, 0xD4389C97, "CityCrc128",  "Google CityHashCrc128WithSeed SSE4.2 (old)" },
@@ -183,6 +187,7 @@ HashInfo g_hashes[] =
   { farmhash64_c_test,    64, FARM64_SEED, "farmhash64_c",  "farmhash64_with_seed (C99)" },
   { farmhash128_c_test,  128, FARM128_SEED,"farmhash128_c", "farmhash128_with_seed (C99)" },
 #endif
+
   { xxHash32_test,        32, 0xBA88B743, "xxHash32",    "xxHash, 32-bit for x64" },
   { xxHash64_test,        64, 0x024B7CF4, "xxHash64",    "xxHash, 64-bit" },
   { xxh3_test,            64, 0xECA5AAE7, "xxh3",        "xxHash v3, 64-bit" },
@@ -191,6 +196,7 @@ HashInfo g_hashes[] =
 #if 0
   { xxhash256_test,       64, 0x024B7CF4, "xxhash256",   "xxhash256, 64-bit unportable" },
 #endif
+
   { SpookyHash32_test,    32, 0x3F798BBB, "Spooky32",    "Bob Jenkins' SpookyHash, 32-bit result" },
   { SpookyHash64_test,    64, 0xA7F955F1, "Spooky64",    "Bob Jenkins' SpookyHash, 64-bit result" },
   { SpookyHash128_test,  128, 0x8D263080, "Spooky128",   "Bob Jenkins' SpookyHash, 128-bit result" },
@@ -322,26 +328,6 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
   }
 
   //-----------------------------------------------------------------------------
-  // Differential tests
-
-  if(g_testDiff || g_testAll)
-  {
-    printf("[[[ Differential Tests ]]]\n\n");
-    fflush(NULL);
-
-    bool result = true;
-    bool dumpCollisions = false;
-
-    result &= DiffTest< Blob<64>,  hashtype >(hash,5,100,dumpCollisions);
-    result &= DiffTest< Blob<128>, hashtype >(hash,4,100,dumpCollisions);
-    result &= DiffTest< Blob<256>, hashtype >(hash,3,100,dumpCollisions);
-
-    if(!result) printf("*********FAIL*********\n");
-    printf("\n");
-    fflush(NULL);
-  }
-
-  //-----------------------------------------------------------------------------
   // Differential-distribution tests
 
   if(g_testDiffDist /*|| g_testAll*/)
@@ -371,26 +357,31 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     result &= AvalancheTest< Blob< 40>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob< 48>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob< 56>, hashtype > (hash,300000);
-
     result &= AvalancheTest< Blob< 64>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob< 72>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob< 80>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob< 88>, hashtype > (hash,300000);
 
     result &= AvalancheTest< Blob< 96>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<104>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob<112>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<120>, hashtype > (hash,300000);
-
     result &= AvalancheTest< Blob<128>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<136>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<144>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<152>, hashtype > (hash,300000);
 
     result &= AvalancheTest< Blob<160>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<168>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<176>, hashtype > (hash,300000);
-    result &= AvalancheTest< Blob<184>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<192>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<224>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<256>, hashtype > (hash,300000);
+
+    result &= AvalancheTest< Blob<320>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<384>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<448>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<512>, hashtype > (hash,300000);
+
+    result &= AvalancheTest< Blob<640>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<768>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<896>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<1024>,hashtype > (hash,300000);
+
+    result &= AvalancheTest< Blob<1280>,hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<1536>,hashtype > (hash,300000);
 
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
@@ -891,6 +882,28 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     printf("\n");
     fflush(NULL);
   }
+
+  //-----------------------------------------------------------------------------
+  // Differential tests
+
+  if(g_testDiff || g_testAll)
+  {
+    printf("[[[ Differential Tests ]]]\n\n");
+    fflush(NULL);
+
+    bool result = true;
+    bool dumpCollisions = false;
+
+    result &= DiffTest< Blob<64>,  hashtype >(hash,5,1000,dumpCollisions);
+    result &= DiffTest< Blob<128>, hashtype >(hash,4,1000,dumpCollisions);
+    result &= DiffTest< Blob<256>, hashtype >(hash,3,1000,dumpCollisions);
+
+    if(!result) printf("*********FAIL*********\n");
+    printf("\n");
+    fflush(NULL);
+  }
+
+
 }
 
 //-----------------------------------------------------------------------------

--- a/main.cpp
+++ b/main.cpp
@@ -194,7 +194,7 @@ HashInfo g_hashes[] =
 
   { xxHash32_test,        32, 0xBA88B743, "xxHash32",    "xxHash, 32-bit for x64" },
   { xxHash64_test,        64, 0x024B7CF4, "xxHash64",    "xxHash, 64-bit" },
-  { xxh3_test,            64, 0xECA5AAE7, "xxh3",        "xxHash v3, 64-bit" },
+  { xxh3_test,            64, 0xF6FED399, "xxh3",        "xxHash v3, 64-bit" },
   { xxh3low_test,         32, 0xECA5AAE7, "xxh3low",     "xxHash v3, 64-bit, low 32-bits part" },
   { xxh3high_test,        32, 0xECA5AAE7, "xxh3high",    "xxHash v3, 64-bit, high 32-bits part" },
   { xxh128_test,         128, 0xECA5AAE7, "xxh128",      "xxHash v3, 128-bit" },

--- a/main.cpp
+++ b/main.cpp
@@ -197,6 +197,9 @@ HashInfo g_hashes[] =
   { xxh3_test,            64, 0xECA5AAE7, "xxh3",        "xxHash v3, 64-bit" },
   { xxh3low_test,         32, 0xECA5AAE7, "xxh3low",     "xxHash v3, 64-bit, low 32-bits part" },
   { xxh3high_test,        32, 0xECA5AAE7, "xxh3high",    "xxHash v3, 64-bit, high 32-bits part" },
+  { xxh128_test,         128, 0xECA5AAE7, "xxh128",      "xxHash v3, 128-bit" },
+  { xxh128low_test,       64, 0xECA5AAE7, "xxh128low",   "xxHash v3, 128-bit, low 64-bits part" },
+  { xxh128high_test,      64, 0xECA5AAE7, "xxh128high",  "xxHash v3, 128-bit, high 64-bits part" },
 #if 0
   { xxhash256_test,       64, 0x024B7CF4, "xxhash256",   "xxhash256, 64-bit unportable" },
 #endif
@@ -388,8 +391,9 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     bool result = true;
     bool drawDiagram = false;
 
-    result &= SparseKeyTest<  24,hashtype>(hash,7,true,true,true,drawDiagram);
-    result &= SparseKeyTest<  32,hashtype>(hash,6,true,true,true,drawDiagram);
+    result &= SparseKeyTest<  16,hashtype>(hash,9,true,true,true,drawDiagram);
+    result &= SparseKeyTest<  24,hashtype>(hash,8,true,true,true,drawDiagram);
+    result &= SparseKeyTest<  32,hashtype>(hash,7,true,true,true,drawDiagram);
     result &= SparseKeyTest<  40,hashtype>(hash,6,true,true,true,drawDiagram);
     result &= SparseKeyTest<  48,hashtype>(hash,6,true,true,true,drawDiagram);
     result &= SparseKeyTest<  56,hashtype>(hash,5,true,true,true,drawDiagram);

--- a/main.cpp
+++ b/main.cpp
@@ -332,22 +332,6 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
   }
 
   //-----------------------------------------------------------------------------
-  // Differential-distribution tests
-
-  if(g_testDiffDist /*|| g_testAll*/)
-  {
-    printf("[[[ Differential Distribution Tests ]]]\n\n");
-    fflush(NULL);
-
-    bool result = true;
-
-    result &= DiffDistTest2<uint64_t,hashtype>(hash);
-
-    printf("\n");
-    fflush(NULL);
-  }
-
-  //-----------------------------------------------------------------------------
   // Avalanche tests
 
   if(g_testAvalanche || g_testAll)
@@ -386,74 +370,6 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
 
     result &= AvalancheTest< Blob<1280>,hashtype > (hash,300000);
     result &= AvalancheTest< Blob<1536>,hashtype > (hash,300000);
-
-    if(!result) printf("*********FAIL*********\n");
-    printf("\n");
-    fflush(NULL);
-  }
-
-  //-----------------------------------------------------------------------------
-  // Bit Independence Criteria. Interesting, but doesn't tell us much about
-  // collision or distribution.
-
-  if(g_testBIC)
-  {
-    printf("[[[ Bit Independence Criteria ]]]\n\n");
-    fflush(NULL);
-
-    bool result = true;
-
-    //result &= BicTest<uint64_t,hashtype>(hash,2000000);
-    BicTest3<Blob<88>,hashtype>(hash,2000000);
-
-    if(!result) printf("*********FAIL*********\n");
-    printf("\n");
-    fflush(NULL);
-  }
-
-  //-----------------------------------------------------------------------------
-  // Keyset 'Cyclic' - keys of the form "abcdabcdabcd..."
-
-  if(g_testCyclic || g_testAll)
-  {
-    printf("[[[ Keyset 'Cyclic' Tests ]]]\n\n");
-    fflush(NULL);
-
-    bool result = true;
-    bool drawDiagram = false;
-
-#if 0
-    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+0,8,100000,drawDiagram);
-#else
-    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+0,8,10000000,drawDiagram);
-    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+1,8,10000000,drawDiagram);
-    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+2,8,10000000,drawDiagram);
-    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+3,8,10000000,drawDiagram);
-    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+4,8,10000000,drawDiagram);
-    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+8,8,10000000,drawDiagram);
-#endif
-    if(!result) printf("*********FAIL*********\n");
-    printf("\n");
-    fflush(NULL);
-  }
-
-  //-----------------------------------------------------------------------------
-  // Keyset 'TwoBytes' - all keys up to N bytes containing two non-zero bytes
-
-  // This generates some huge keysets, 128-bit tests will take ~1.3 gigs of RAM.
-
-  if(g_testTwoBytes || g_testAll)
-  {
-    printf("[[[ Keyset 'TwoBytes' Tests ]]]\n\n");
-    fflush(NULL);
-
-    bool result = true;
-    bool drawDiagram = false;
-
-    for(int i = 4; i <= 24; i += 4)
-    {
-      result &= TwoBytesTest2<hashtype>(hash,i,drawDiagram);
-    }
 
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
@@ -833,6 +749,55 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
   }
 
   //-----------------------------------------------------------------------------
+  // Keyset 'Cyclic' - keys of the form "abcdabcdabcd..."
+
+  if(g_testCyclic || g_testAll)
+  {
+    printf("[[[ Keyset 'Cyclic' Tests ]]]\n\n");
+    fflush(NULL);
+
+    bool result = true;
+    bool drawDiagram = false;
+
+#if 0
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+0,8,100000,drawDiagram);
+#else
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+0,8,10000000,drawDiagram);
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+1,8,10000000,drawDiagram);
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+2,8,10000000,drawDiagram);
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+3,8,10000000,drawDiagram);
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+4,8,10000000,drawDiagram);
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+8,8,10000000,drawDiagram);
+#endif
+    if(!result) printf("*********FAIL*********\n");
+    printf("\n");
+    fflush(NULL);
+  }
+
+  //-----------------------------------------------------------------------------
+  // Keyset 'TwoBytes' - all keys up to N bytes containing two non-zero bytes
+
+  // This generates some huge keysets, 128-bit tests will take ~1.3 gigs of RAM.
+
+  if(g_testTwoBytes || g_testAll)
+  {
+    printf("[[[ Keyset 'TwoBytes' Tests ]]]\n\n");
+    fflush(NULL);
+
+    bool result = true;
+    bool drawDiagram = false;
+
+    for(int i = 4; i <= 24; i += 4)
+    {
+      result &= TwoBytesTest2<hashtype>(hash,i,drawDiagram);
+    }
+
+    if(!result) printf("*********FAIL*********\n");
+    printf("\n");
+    fflush(NULL);
+  }
+
+  //-----------------------------------------------------------------------------
   // Keyset 'Text'
 
   if(g_testText || g_testAll)
@@ -901,6 +866,41 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     result &= DiffTest< Blob<64>,  hashtype >(hash,5,1000,dumpCollisions);
     result &= DiffTest< Blob<128>, hashtype >(hash,4,1000,dumpCollisions);
     result &= DiffTest< Blob<256>, hashtype >(hash,3,1000,dumpCollisions);
+
+    if(!result) printf("*********FAIL*********\n");
+    printf("\n");
+    fflush(NULL);
+  }
+
+  //-----------------------------------------------------------------------------
+  // Differential-distribution tests
+
+  if(g_testDiffDist /*|| g_testAll*/)
+  {
+    printf("[[[ Differential Distribution Tests ]]]\n\n");
+    fflush(NULL);
+
+    bool result = true;
+
+    result &= DiffDistTest2<uint64_t,hashtype>(hash);
+
+    printf("\n");
+    fflush(NULL);
+  }
+
+  //-----------------------------------------------------------------------------
+  // Bit Independence Criteria. Interesting, but doesn't tell us much about
+  // collision or distribution.
+
+  if(g_testBIC)
+  {
+    printf("[[[ Bit Independence Criteria ]]]\n\n");
+    fflush(NULL);
+
+    bool result = true;
+
+    //result &= BicTest<uint64_t,hashtype>(hash,2000000);
+    BicTest3<Blob<88>,hashtype>(hash,2000000);
 
     if(!result) printf("*********FAIL*********\n");
     printf("\n");

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@
 //-----------------------------------------------------------------------------
 // Configuration. TODO - move these to command-line flags
 
-bool g_testAll = false;
+bool g_testAll = true;
 
 bool g_testSanity      = false;
 bool g_testSpeed       = false;

--- a/main.cpp
+++ b/main.cpp
@@ -75,9 +75,9 @@ HashInfo g_hashes[] =
   { DoNothingHash,        64, 0x00000000, "donothing64", "Do-Nothing function (only valid for measuring call overhead)" },
   { DoNothingHash,       128, 0x00000000, "donothing128", "Do-Nothing function (only valid for measuring call overhead)" },
   { NoopOAATReadHash,     64, 0x00000000, "NOP_OAAT_read64", "Noop function (only valid for measuring call + OAAT reading overhead)" },
-  { BadHash,     	  32, 0xAB432E23, "BadHash", 	 "very simple XOR shift" },
-  { sumhash,     	  32, 0x0000A9AC, "sumhash", 	 "sum all bytes" },
-  { sumhash32,     	  32, 0xF5562C80, "sumhash32",   "sum all 32bit words" },
+  { BadHash,     	        32, 0xAB432E23, "BadHash", 	 "very simple XOR shift" },
+  { sumhash,     	        32, 0x0000A9AC, "sumhash", 	 "sum all bytes" },
+  { sumhash32,     	      32, 0xF5562C80, "sumhash32",   "sum all 32bit words" },
 
   // here start the real hashes. the problematic ones:
   { crc32,                32, 0x3719DB20, "crc32",       "CRC-32 soft" },
@@ -121,7 +121,7 @@ HashInfo g_hashes[] =
   { fletcher2,            64, 0x0, "fletcher2",  "fletcher2 ZFS"} //TODO
   { fletcher4,            64, 0x0, "fletcher4",  "fletcher4 ZFS"} //TODO
   { Jesteress,            32, 0x0, "Jesteress",  "FNV1a-Jesteress 32-bit sanmayce" },
-  { Meiyan,       	  32, 0x0, "Meiyan",     "FNV1a-Meiyan 32-bit sanmayce" },
+  { Meiyan,       	      32, 0x0, "Meiyan",     "FNV1a-Meiyan 32-bit sanmayce" },
 #endif
   { Bernstein,            32, 0xBDB4B640, "bernstein",   "Bernstein, 32-bit" },
   { sdbm,                 32, 0x582AF769, "sdbm",        "sdbm as in perl5" },
@@ -168,20 +168,24 @@ HashInfo g_hashes[] =
   { mum_high_test,        32, MUM_SEED,   "MUMhigh",     "github.com/vnmakarov/mum-hash" },
 
   { CityHash32_test,      32, 0x5C28AD62, "City32",      "Google CityHash32WithSeed (old)" },
-  { CityHash64_test,      64, 0x25A20825, "City64",      "Google CityHash64WithSeed (old)" },
   { CityHash64noSeed_test,64, 0x63FC6063, "City64noSeed","Google CityHash64 without seed (default version, misses one final avalanche)" },
+  { CityHash64_test,      64, 0x25A20825, "City64",      "Google CityHash64WithSeed (old)" },
+  { CityHash64_low_test,  32, 0xCC5BC861, "City64low",   "Google CityHash64WithSeed (low 32-bits)" },
+  { CityHash64_high_test, 32, 0xC94A0E6B, "City64high",  "Google CityHash64WithSeed (high 32-bits)" },
 #if defined(__SSE4_2__) && defined(__x86_64__)
   { CityHash128_test,    128, 0x6531F54E, "City128",     "Google CityHash128WithSeed (old)" },
   { CityHashCrc128_test, 128, 0xD4389C97, "CityCrc128",  "Google CityHashCrc128WithSeed SSE4.2 (old)" },
 #endif
-# ifdef _MSC_VER /* truncated long to 32 */
+
+#ifdef _MSC_VER /* truncated long to 32 */
 #  define FARM64_SEED         0xEBC4A679
 #  define FARM128_SEED        0x305C0D9A
-# else
+#else
 #  define FARM64_SEED         0x35F84A93
 #  define FARM128_SEED        0x9E636AAE
-# endif
+#endif
   { FarmHash64_test,      64, FARM64_SEED, "FarmHash64",  "Google FarmHash64WithSeed" },
+  { FarmHash64noSeed_test,64, 0xA5B9146C, "Farm64noSeed", "Google FarmHash64 without seed (default, misses on final avalanche)" },
   { FarmHash128_test,    128, FARM128_SEED,"FarmHash128", "Google FarmHash128WithSeed" },
 #if defined(__SSE4_2__) && defined(__x86_64__)
   { farmhash64_c_test,    64, FARM64_SEED, "farmhash64_c",  "farmhash64_with_seed (C99)" },
@@ -821,7 +825,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     bool testDistribution = false;
     bool drawDiagram = false;
 
-    result &= WindowedKeyTest< Blob<hashbits*2>, hashtype > ( hash, 20, testCollision, testDistribution, drawDiagram );
+    result &= WindowedKeyTest< Blob<hashbits*2+2>, hashtype > ( hash, 20, testCollision, testDistribution, drawDiagram );
 
     if(!result) printf("*********FAIL*********\n");
     printf("\n");

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@
 //-----------------------------------------------------------------------------
 // Configuration. TODO - move these to command-line flags
 
-bool g_testAll = true;
+bool g_testAll = false;
 
 bool g_testSanity      = false;
 bool g_testSpeed       = false;
@@ -29,6 +29,8 @@ bool g_testWindow      = false;
 bool g_testText        = false;
 bool g_testZeroes      = false;
 bool g_testSeed        = false;
+
+bool g_testdist        = true;
 
 struct TestOpts {
   bool         &var;
@@ -183,6 +185,9 @@ HashInfo g_hashes[] =
 #endif
   { xxHash32_test,        32, 0xBA88B743, "xxHash32",    "xxHash, 32-bit for x64" },
   { xxHash64_test,        64, 0x024B7CF4, "xxHash64",    "xxHash, 64-bit" },
+  { xxh3_test,            64, 0xECA5AAE7, "xxh3",        "xxHash v3, 64-bit" },
+  { xxh3low_test,         32, 0xECA5AAE7, "xxh3low",     "xxHash v3, 64-bit, low 32-bits part" },
+  { xxh3high_test,        32, 0xECA5AAE7, "xxh3high",    "xxHash v3, 64-bit, high 32-bits part" },
 #if 0
   { xxhash256_test,       64, 0x024B7CF4, "xxhash256",   "xxhash256, 64-bit unportable" },
 #endif
@@ -270,7 +275,7 @@ void SelfTest ( void )
 //----------------------------------------------------------------------------
 
 template < typename hashtype >
-void test ( hashfunc<hashtype> hash, HashInfo * info )
+void test ( hashfunc<hashtype> hash, HashInfo* info )
 {
   const int hashbits = sizeof(hashtype) * 8;
 
@@ -327,9 +332,9 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
     bool result = true;
     bool dumpCollisions = false;
 
-    result &= DiffTest< Blob<64>,  hashtype >(hash,5,1000,dumpCollisions);
-    result &= DiffTest< Blob<128>, hashtype >(hash,4,1000,dumpCollisions);
-    result &= DiffTest< Blob<256>, hashtype >(hash,3,1000,dumpCollisions);
+    result &= DiffTest< Blob<64>,  hashtype >(hash,5,100,dumpCollisions);
+    result &= DiffTest< Blob<128>, hashtype >(hash,4,100,dumpCollisions);
+    result &= DiffTest< Blob<256>, hashtype >(hash,3,100,dumpCollisions);
 
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
@@ -382,6 +387,11 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
     result &= AvalancheTest< Blob<144>, hashtype > (hash,300000);
     result &= AvalancheTest< Blob<152>, hashtype > (hash,300000);
 
+    result &= AvalancheTest< Blob<160>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<168>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<176>, hashtype > (hash,300000);
+    result &= AvalancheTest< Blob<184>, hashtype > (hash,300000);
+
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
     fflush(NULL);
@@ -425,6 +435,7 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
     result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+2,8,10000000,drawDiagram);
     result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+3,8,10000000,drawDiagram);
     result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+4,8,10000000,drawDiagram);
+    result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+8,8,10000000,drawDiagram);
 #endif
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
@@ -444,7 +455,7 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
     bool result = true;
     bool drawDiagram = false;
 
-    for(int i = 4; i <= 20; i += 4)
+    for(int i = 4; i <= 24; i += 4)
     {
       result &= TwoBytesTest2<hashtype>(hash,i,drawDiagram);
     }
@@ -467,12 +478,34 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
 
     result &= SparseKeyTest<  32,hashtype>(hash,6,true,true,true,drawDiagram);
     result &= SparseKeyTest<  40,hashtype>(hash,6,true,true,true,drawDiagram);
-    result &= SparseKeyTest<  48,hashtype>(hash,5,true,true,true,drawDiagram);
+    result &= SparseKeyTest<  48,hashtype>(hash,6,true,true,true,drawDiagram);
     result &= SparseKeyTest<  56,hashtype>(hash,5,true,true,true,drawDiagram);
     result &= SparseKeyTest<  64,hashtype>(hash,5,true,true,true,drawDiagram);
+    result &= SparseKeyTest<  72,hashtype>(hash,5,true,true,true,drawDiagram);
     result &= SparseKeyTest<  96,hashtype>(hash,4,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 112,hashtype>(hash,4,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 128,hashtype>(hash,4,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 144,hashtype>(hash,4,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 160,hashtype>(hash,4,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 192,hashtype>(hash,4,true,true,true,drawDiagram);
     result &= SparseKeyTest< 256,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 288,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 320,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 384,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 448,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 512,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 640,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 768,hashtype>(hash,3,true,true,true,drawDiagram);
+    result &= SparseKeyTest< 896,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<1024,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<1280,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<1536,hashtype>(hash,2,true,true,true,drawDiagram);
     result &= SparseKeyTest<2048,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<3072,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<4096,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<6144,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<8192,hashtype>(hash,2,true,true,true,drawDiagram);
+    result &= SparseKeyTest<9992,hashtype>(hash,2,true,true,true,drawDiagram);
 
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
@@ -521,7 +554,7 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
         0x20000000, 0x40000000, 0x60000000, 0x80000000, 0xA0000000, 0xC0000000, 0xE0000000
       };
 
-      result &= CombinationKeyTest<hashtype>(hash,8,blocks,sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
+      result &= CombinationKeyTest(hash,8,blocks,sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
 
       if(!result) printf("*********FAIL*********\n");
       printf("\n");
@@ -542,7 +575,7 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
         0x80000000,
       };
 
-      result &= CombinationKeyTest<hashtype>(hash,20,blocks,sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
+      result &= CombinationKeyTest(hash, 23, blocks, sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
 
       if(!result) printf("*********FAIL*********\n");
       printf("\n");
@@ -562,7 +595,197 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
         0x00000001,
       };
 
-      result &= CombinationKeyTest<hashtype>(hash,20,blocks,sizeof(blocks) / sizeof(uint32_t),true,true,drawDiagram);
+      result &= CombinationKeyTest(hash, 23, blocks, sizeof(blocks) / sizeof(uint32_t), true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 0x800000000000000' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      uint64_t blocks[] =
+      {
+        0x0000000000000000ULL,
+
+        0x8000000000000000ULL,
+      };
+
+      result &= CombinationKeyTest(hash, 23, blocks, sizeof(blocks) / sizeof(uint64_t), true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 0x000000000000001' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      uint64_t blocks[] =
+      {
+        0x0000000000000000ULL,
+
+        0x0000000000000001ULL,
+      };
+
+      result &= CombinationKeyTest(hash, 23, blocks, sizeof(blocks) / sizeof(uint64_t), true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 16-bytes [0-1]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      block16 blocks[2];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[0] = 1;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, 2, true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 16-bytes [0-last]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      size_t const nbElts = 2;
+      block16 blocks[nbElts];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[sizeof(blocks[0].c)-1] = 0x80;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, nbElts, true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 32-bytes [0-1]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      block32 blocks[2];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[0] = 1;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, 2, true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 32-bytes [0-last]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      size_t const nbElts = 2;
+      block32 blocks[nbElts];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[sizeof(blocks[0].c)-1] = 0x80;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, nbElts, true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 64-bytes [0-1]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      block64 blocks[2];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[0] = 1;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, 2, true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 64-bytes [0-last]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      size_t const nbElts = 2;
+      block64 blocks[nbElts];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[sizeof(blocks[0].c)-1] = 0x80;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, nbElts, true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 128-bytes [0-1]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      block128 blocks[2];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[0] = 1;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, 2, true, true, drawDiagram);
+
+      if(!result) printf("*********FAIL*********\n");
+      printf("\n");
+      fflush(NULL);
+    }
+
+    {
+      printf("[[[ Keyset 'Combination 128-bytes [0-last]' Tests ]]]\n\n");
+      fflush(NULL);
+
+      bool result = true;
+      bool drawDiagram = false;
+
+      size_t const nbElts = 2;
+      block128 blocks[nbElts];
+      memset(blocks, 0, sizeof(blocks));
+      blocks[0].c[sizeof(blocks[0].c)-1] = 0x80;   // presumes little endian
+
+      result &= CombinationKeyTest(hash, 23, blocks, nbElts, true, true, drawDiagram);
 
       if(!result) printf("*********FAIL*********\n");
       printf("\n");
@@ -662,7 +885,7 @@ void test ( hashfunc<hashtype> hash, HashInfo * info )
     bool result = true;
     bool drawDiagram = false;
 
-    result &= SeedTest<hashtype>( hash, 1000000, drawDiagram );
+    result &= SeedTest<hashtype>( hash, 5000000, drawDiagram );
 
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
@@ -680,12 +903,12 @@ HashInfo * g_hashUnderTest = NULL;
 
 void VerifyHash ( const void * key, int len, uint32_t seed, void * out )
 {
-  g_inputVCode = MurmurOAAT(key,len,g_inputVCode);
-  g_inputVCode = MurmurOAAT(&seed,sizeof(uint32_t),g_inputVCode);
+  g_inputVCode = MurmurOAAT(key, len, g_inputVCode);
+  g_inputVCode = MurmurOAAT(&seed, sizeof(uint32_t), g_inputVCode);
 
-  g_hashUnderTest->hash(key,len,seed,out);
+  g_hashUnderTest->hash(key, len, seed, out);
 
-  g_outputVCode = MurmurOAAT(out,g_hashUnderTest->hashbits/8,g_outputVCode);
+  g_outputVCode = MurmurOAAT(out, g_hashUnderTest->hashbits/8, g_outputVCode);
 }
 
 //-----------------------------------------------------------------------------
@@ -730,23 +953,22 @@ void testHash ( const char * name )
 #ifdef _MSC_VER
 static char* strndup(char const *s, size_t n)
 {
-  size_t len = strnlen(s, n);
+  size_t const len = strnlen(s, n);
   char *p = (char*) malloc(len + 1);
-
-  if (p == NULL)
-    return NULL;
-
+  if (p == NULL) return NULL;
+  memcpy(p, s, len);
   p[len] = '\0';
-  return (char*) memcpy(p, s, len);
+  return p;
 }
 #endif
 
-int main ( int argc, char ** argv )
+
+int main ( int argc, const char ** argv )
 {
 #if (defined(__x86_64__) && __SSE4_2__) || defined(_M_X64) || defined(_X86_64_)
-  const char * defaulthash = "t1ha2_atonce"; /* "murmur3a"; */
+  const char * defaulthash = "xxh3"; /* "murmur3a"; */
 #else
-  const char * defaulthash = "t1ha0_32le";
+  const char * defaulthash = "murmur3a";
 #endif
   const char * hashToTest = defaulthash;
 
@@ -803,7 +1025,7 @@ int main ( int argc, char ** argv )
 
   // Code runs on the 3rd CPU by default
   //SetAffinity((1 << 2));
-  SelfTest();
+  //SelfTest();
 
   int timeBegin = clock();
 
@@ -813,8 +1035,8 @@ int main ( int argc, char ** argv )
 
   printf("\n");
   fflush(NULL);
-  printf("Input vcode 0x%08x, Output vcode 0x%08x, Result vcode 0x%08x\n",g_inputVCode,g_outputVCode,g_resultVCode);
-  printf("Verification value is 0x%08x - Testing took %f seconds\n",g_verify,double(timeEnd-timeBegin)/double(CLOCKS_PER_SEC));
+  printf("Input vcode 0x%08x, Output vcode 0x%08x, Result vcode 0x%08x\n", g_inputVCode, g_outputVCode, g_resultVCode);
+  printf("Verification value is 0x%08x - Testing took %f seconds\n", g_verify, double(timeEnd-timeBegin)/double(CLOCKS_PER_SEC));
   printf("-------------------------------------------------------------------------------\n");
   fflush(NULL);
   return 0;

--- a/mum.h
+++ b/mum.h
@@ -97,7 +97,7 @@ static uint64_t _mum_unroll_prime = 0x7b51ec3d22f7096fULL;
 static uint64_t _mum_tail_prime = 0xaf47d47c99b1461bULL;
 static uint64_t _mum_finish_prime1 = 0xa9a7ae7ceff79f3fULL;
 static uint64_t _mum_finish_prime2 = 0xaf47d47c99b1461bULL;
-  
+
 static uint64_t _mum_primes [] = {
   0X9ebdcae10d981691, 0X32b9b9b97a27ac7d, 0X29b5584d83d35bbd, 0X4b04e0e61401255f,
   0X25e8f7b1f1c9d027, 0X80d4c8c000f3e881, 0Xbd1255431904b9dd, 0X8a3bd4485eee6d81,
@@ -133,7 +133,7 @@ _mum (uint64_t v, uint64_t p) {
   uint64_t rm_1 = hp * lv;
   uint64_t rl =  lv * lp;
   uint64_t t, carry = 0;
-  
+
   /* We could ignore a carry bit here if we did not care about the
      same hash for 32-bit and 64-bit targets.  */
   t = rl + (rm_0 << 32);
@@ -223,7 +223,7 @@ _mum_hash_aligned (uint64_t start, const void *key, size_t len) {
   uint64_t u64;
   size_t i;
   size_t n;
-  
+
   result = _mum (result, _mum_block_start_prime);
   while  (len > _MUM_UNROLL_FACTOR * sizeof (uint64_t)) {
     /* This loop could be vectorized when we have vector insns for
@@ -320,14 +320,14 @@ _mum_hash_avx2 (const void * key, size_t len, uint64_t seed) {
 
 static inline uint64_t
 #if defined(__x86_64__)
-_MUM_TARGET("inline-all-stringops")
+//_MUM_TARGET("inline-all-stringops")
 #endif
 _mum_hash_default (const void *key, size_t len, uint64_t seed) {
   uint64_t result;
   const unsigned char *str = (const unsigned char *) key;
   size_t block_len;
   uint64_t buf[_MUM_BLOCK_LEN / sizeof (uint64_t)];
-  
+
   result = seed + len;
   if (_MUM_UNALIGNED_ACCESS || ((size_t) str & 0x7) == 0)
     result = _mum_hash_aligned (result, key, len);
@@ -347,7 +347,7 @@ static inline uint64_t
 _mum_next_factor (void) {
   uint64_t start = 0;
   int i;
-  
+
   for (i = 0; i < 8; i++)
     start = (start << 8) | rand() % 256;
   return start;

--- a/mum.h
+++ b/mum.h
@@ -217,9 +217,9 @@ _mum_le32 (uint32_t v) {
 #define _MUM_UNROLL_FACTOR (1 << _MUM_UNROLL_FACTOR_POWER)
 
 static inline uint64_t _MUM_OPTIMIZE("unroll-loops")
-_mum_hash_aligned (uint64_t start, const void *key, size_t len) {
+_mum_hash_aligned (uint64_t start, const void* key, size_t len) {
   uint64_t result = start;
-  const unsigned char *str = (const unsigned char *) key;
+  const unsigned char* str = (const unsigned char*) key;
   uint64_t u64;
   size_t i;
   size_t n;
@@ -228,7 +228,7 @@ _mum_hash_aligned (uint64_t start, const void *key, size_t len) {
   while  (len > _MUM_UNROLL_FACTOR * sizeof (uint64_t)) {
     /* This loop could be vectorized when we have vector insns for
        64x64->128-bit multiplication.  AVX2 currently only have a
-       vector insn for 4 32x32->64-bit multiplication.  */
+       vector insn for 4 32x32->64-bit multiplication. */
     for (i = 0; i < _MUM_UNROLL_FACTOR; i++)
       result ^= _mum (_mum_le (((uint64_t *) str)[i]), _mum_primes[i]);
     len -= _MUM_UNROLL_FACTOR * sizeof (uint64_t);

--- a/xxh3.h
+++ b/xxh3.h
@@ -1,0 +1,430 @@
+#ifndef XXH3_H
+#define XXH3_H
+
+
+/* ===   Dependencies   === */
+
+#undef XXH_INLINE_ALL   /* in case it's already defined */
+#define XXH_INLINE_ALL
+#include "xxhash.h"
+
+#define NDEBUG
+#include <assert.h>
+
+
+/* ===   Compiler versions   === */
+
+#if !(defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)   /* C99+ */
+#  define restrict   /* disable */
+#endif
+
+#if defined(__GNUC__)
+#  if defined(__SSE2__)
+#    include <x86intrin.h>
+#  endif
+#  define ALIGN(n)      __attribute__ ((aligned(n)))
+#elif defined(_MSC_VER)
+#  include <intrin.h>
+#  define ALIGN(n)      __declspec(align(n))
+#else
+#  define ALIGN(n)   /* disabled */
+#endif
+
+
+
+/* ==========================================
+ * Vectorization detection
+ * ========================================== */
+#define XXH_SCALAR 0
+#define XXH_SSE2   1
+#define XXH_AVX2   2
+
+#ifndef XXH_VECTOR    /* can be defined on command line */
+#  if defined(__AVX2__)
+#    define XXH_VECTOR XXH_AVX2
+#  elif defined(__SSE2__)
+#    define XXH_VECTOR XXH_SSE2
+#  else
+#    define XXH_VECTOR XXH_SCALAR
+#  endif
+#endif
+
+
+
+/* ==========================================
+ * Short keys
+ * ========================================== */
+
+static U64 XXH3_mixHigh(U64 val) {
+  return val ^ (val >> 47);
+}
+
+static U64 XXH3_finalMerge_2u64(U64 ll1, U64 ll2, U64 mul)
+{
+    U64 const ll11 = XXH3_mixHigh((ll1 ^ ll2) * mul);
+    U64 const ll21 = XXH3_mixHigh((ll2 ^ ll11) * mul);
+    return ll21 * mul;
+}
+
+static U64 XXH3_finalMerge_4u64(U64 ll1, U64 ll2, U64 ll3, U64 ll4, U64 mul)
+{
+    U64 const ll11 = XXH_rotl64(ll1 + ll2, 43) + XXH_rotl64(ll3, 30) + ll4;
+    U64 const ll12 = ll1 + XXH_rotl64(ll2, 18) + ll3 + PRIME64_3;
+
+    return XXH3_finalMerge_2u64(ll11, ll12, mul);
+}
+
+static U64 XXH3_finalMerge_8u64(U64 ll1, U64 ll2, U64 ll3, U64 ll4,
+                                U64 ll5, U64 ll6, U64 ll7, U64 ll8,
+                                U64 mul)
+{
+    U64 const ll11 = XXH_rotl64(ll1 + ll7, 21) + (XXH_rotl64(ll2, 34) + ll3) * 9;
+    U64 const ll12 = ((ll1 + ll2) ^ ll4) + ll6 + 1;
+    U64 const ll13 = XXH_rotl64(ll5 + ll6, 22) + ll3;
+    U64 const ll14 = ll5 + XXH_rotl64(ll8, 11) + ll3;
+
+    U64 const ll21 = XXH_swap64((ll11 + ll12) * mul) + ll8;
+    U64 const ll31 = (XXH_swap64((ll12 + ll21) * mul) + ll7) * mul;
+    U64 const ll41 = XXH_swap64((ll13 + ll14) * mul + ll31) + ll2;
+    U64 const ll51 = XXH3_mixHigh((ll14 + ll41) * mul + ll4 + ll8) * mul;
+
+    return ll51 + ll13;
+}
+
+
+XXH_FORCE_INLINE U64 XXH3_len_1to3_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len > 0 && len <= 3);
+    {   BYTE const c1 = ((const BYTE*)data)[0];
+        BYTE const c2 = ((const BYTE*)data)[len >> 1];
+        BYTE const c3 = ((const BYTE*)data)[len - 1];
+        U32  const l1 = (U32)(c1) + ((U32)(c2) << 8);
+        U32  const l2 = (U32)(len) + ((U32)(c3) << 2);
+        U64  const ll3 = (l1 * PRIME64_2) ^ (l2 * PRIME64_1);
+        return XXH3_mixHigh(ll3) * PRIME64_3;
+    }
+}
+
+
+XXH_FORCE_INLINE U64 XXH3_len_4to8_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len >= 4 && len <= 8);
+    {   U64 const mul = PRIME64_2 + (len * 2);  /* keep it odd */
+        U64 const ll1 = XXH_read32(data);
+        U64 const ll2 = XXH_read32((const BYTE*)data + len - 4) + PRIME64_1;
+        return XXH3_finalMerge_2u64((len-1) + (ll1 << 3), ll2, mul);
+    }
+}
+
+XXH_FORCE_INLINE U64 XXH3_len_9to16_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len >= 9 && len <= 16);
+    {   U64 const ll1 = XXH_read64(data) + PRIME64_1;
+        U64 const ll2 = XXH_read64((const BYTE*)data + len - 8);
+        U64 const mul = PRIME64_2 + (len * 2);  /* keep it odd */
+        U64 const ll11 = (ll1 * mul) + XXH_rotl64(ll2, 23);
+        U64 const ll12 = (ll2 * mul) + XXH_rotl64(ll1, 37);
+        return XXH3_finalMerge_2u64(ll11, ll12, mul);
+    }
+}
+
+XXH_FORCE_INLINE U64 XXH3_len_1to16_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len > 0 && len <= 16);
+    {   if (len > 8) return XXH3_len_9to16_64b(data, len);
+        if (len >= 4) return XXH3_len_4to8_64b(data, len);
+        return XXH3_len_1to3_64b(data, len);
+    }
+}
+
+
+static U64 XXH3_len_17to32_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len > 16 && len <= 32);
+
+    {   const BYTE* const p = (const BYTE*)data;
+
+        U64 const mul = PRIME64_3 + len * 2;  /* keep it odd */
+        U64 const ll1 = XXH_read64(p) * PRIME64_1;
+        U64 const ll2 = XXH_read64(p + 8);
+        U64 const ll3 = XXH_read64(p + len - 8) * mul;
+        U64 const ll4 = XXH_read64(p + len - 16) * PRIME64_2;
+
+        return XXH3_finalMerge_4u64(ll1, ll2, ll3, ll4, mul);
+    }
+}
+
+
+static U64 XXH3_len_33to64_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len > 33 && len <= 64);
+
+    {   const BYTE* const p = (const BYTE*)data;
+
+        U64 const mul = PRIME64_2 + len * 2;   /* keep it odd */
+
+        U64 const ll1 = XXH_read64(p);
+        U64 const ll2 = XXH_read64(p + 8);
+        U64 const ll3 = XXH_read64(p + 16);
+        U64 const ll4 = XXH_read64(p + 24);
+        U64 const ll5 = XXH_read64(p + len - 32);
+        U64 const ll6 = XXH_read64(p + len - 24);
+        U64 const ll7 = XXH_read64(p + len - 16);
+        U64 const ll8 = XXH_read64(p + len - 8);
+
+        return XXH3_finalMerge_8u64(ll1, ll2, ll3, ll4, ll5, ll6, ll7, ll8, mul);
+    }
+}
+
+
+static U64 XXH3_len_65to96_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len > 64 && len <= 96);
+
+    {   const BYTE* const p = (const BYTE*)data;
+
+        U64 const ll1 = XXH3_len_33to64_64b(data, 64);
+        U64 const ll2 = XXH3_len_17to32_64b(p + len - 32, 32);
+        return XXH3_finalMerge_2u64(ll1, ll2, PRIME64_1 + 2*len);
+    }
+}
+
+static U64 XXH3_len_97to128_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len > 96 && len <= 128);
+
+    {   const BYTE* const p = (const BYTE*)data;
+
+        U64 const ll1 = XXH3_len_33to64_64b(data, 64);
+        U64 const ll2 = XXH3_len_33to64_64b(p + 64, len - 64);
+        return XXH3_finalMerge_2u64(ll1, ll2, PRIME64_1 + 2*len);
+    }
+}
+
+
+
+/* ==========================================
+ * Long keys
+ * ========================================== */
+
+#define STRIPE_LEN 64
+#define STRIPE_ELTS (STRIPE_LEN / sizeof(U32))
+#define KEYSET_DEFAULT_SIZE 48   /* minimum 32 */
+
+
+ALIGN(64) static const U32 kKey[KEYSET_DEFAULT_SIZE] = {
+    0xb8fe6c39,0x23a44bbe,0x7c01812c,0xf721ad1c,
+    0xded46de9,0x839097db,0x7240a4a4,0xb7b3671f,
+    0xcb79e64e,0xccc0e578,0x825ad07d,0xccff7221,
+    0xb8084674,0xf743248e,0xe03590e6,0x813a264c,
+    0x3c2852bb,0x91c300cb,0x88d0658b,0x1b532ea3,
+    0x71644897,0xa20df94e,0x3819ef46,0xa9deacd8,
+    0xa8fa763f,0xe39c343f,0xf9dcbbc7,0xc70b4f1d,
+    0x8a51e04b,0xcdb45931,0xc89f7ec9,0xd9787364,
+
+    0xeac5ac83,0x34d3ebc3,0xc581a0ff,0xfa1363eb,
+    0x170ddd51,0xb7f0da49,0xd3165526,0x29d4689e,
+    0x2b16be58,0x7d47a1fc,0x8ff8b8d1,0x7ad031ce,
+    0x45cb3a8f,0x95160428,0xafd7fbca,0xbb4b407e,
+};
+
+#define ACC_NB (STRIPE_LEN / sizeof(U64))
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512(void* acc, const void *restrict data, const void *restrict key)
+{
+#if (XXH_VECTOR == XXH_AVX2)
+
+    assert(((size_t)acc) & 31 == 0);
+    {                   __m256i* const xacc  =       (__m256i *) acc;
+                  const __m256i* const xdata = (const __m256i *) data;
+        ALIGN(32) const __m256i* const xkey  = (const __m256i *) key;
+
+        for (size_t i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+            __m256i const d   = _mm256_loadu_si256 (xdata+i);
+            __m256i const k   = _mm256_loadu_si256 (xkey+i);
+            __m256i const dk  = _mm256_add_epi32 (d,k);                                  /* uint32 dk[8]  = {d0+k0, d1+k1, d2+k2, d3+k3, ...} */
+            __m256i const res = _mm256_mul_epu32 (dk, _mm256_shuffle_epi32 (dk,0x31));   /* uint64 res[4] = {dk0*dk1, dk2*dk3, ...} */
+            xacc[i]           = _mm256_add_epi64(res, xacc[i]);                          /* xacc must be aligned on 32 bytes boundaries */
+        }
+    }
+
+#elif (XXH_VECTOR == XXH_SSE2)
+
+    assert(((size_t)acc) & 15 == 0);
+    {                   __m128i* const xacc  =       (__m128i *) acc;
+                  const __m128i* const xdata = (const __m128i *) data;
+        ALIGN(16) const __m128i* const xkey  = (const __m128i *) key;
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+            __m128i const d   = _mm_loadu_si128 (xdata+i);
+            __m128i const k   = _mm_loadu_si128 (xkey+i);
+            __m128i const dk  = _mm_add_epi32 (d,k);                               /* uint32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+            __m128i const res = _mm_mul_epu32 (dk, _mm_shuffle_epi32 (dk,0x31));   /* uint64 res[2] = {dk0*dk1,dk2*dk3} */
+            xacc[i]           = _mm_add_epi64(res, xacc[i]);                       /* xacc must be aligned on 16 bytes boundaries */
+        }
+    }
+
+#else   /* scalar variant */
+
+          U64* const xacc  =       (U64*) acc;
+    const U32* const xdata = (const U32*) data;
+    const U32* const xkey  = (const U32*) key;
+
+    int i;
+    for (i=0; i < (int)ACC_NB; i++) {
+        int const left = 2*i;
+        int const right= 2*i + 1;
+        xacc[i] += (xdata[left] + xkey[left]) * (U64)(xdata[right] + xkey[right]);
+    }
+
+#endif
+}
+
+static void XXH3_scrambleAcc(void* acc, const void* key)
+{
+#if (XXH_VECTOR == XXH_AVX2)
+
+    assert(((size_t)acc) & 31 == 0);
+    {   __m256i* const xacc = (__m256i*) acc;
+        const __m256i* const xkey  = (const __m256i *) key;
+
+        __m256i const xor_p5 = _mm256_set1_epi64x(PRIME64_5);
+
+        for (size_t i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+            __m256i data = xacc[i];
+            __m256i const shifted = _mm256_srli_epi64(data, 47);
+            data = _mm256_xor_si256(data, shifted);
+            data = _mm256_xor_si256(data, xor_p5);
+
+            {   __m256i const k   = _mm256_loadu_si256 (xkey+i);
+                __m256i const dk  = _mm256_mul_epu32 (data,k);          /* U32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+
+                __m256i const d2  = _mm256_shuffle_epi32 (data,0x31);
+                __m256i const k2  = _mm256_shuffle_epi32 (k,0x31);
+                __m256i const dk2 = _mm256_mul_epu32 (d2,k2);           /* U32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+
+                xacc[i] = _mm256_xor_si256(dk, dk2);
+        }   }
+    }
+
+#elif (XXH_VECTOR == XXH_SSE2)
+
+    assert(((size_t)acc) & 15 == 0);
+    {   __m128i* const xacc = (__m128i*) acc;
+        const __m128i* const xkey  = (const __m128i *) key;
+        __m128i const xor_p5 = _mm_set1_epi64((__m64)PRIME64_5);
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+            __m128i data = xacc[i];
+            __m128i const shifted = _mm_srli_epi64(data, 47);
+            data = _mm_xor_si128(data, shifted);
+            data = _mm_xor_si128(data, xor_p5);
+
+            {   __m128i const k   = _mm_loadu_si128 (xkey+i);
+                __m128i const dk  = _mm_mul_epu32 (data,k);          /* U32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+
+                __m128i const d2  = _mm_shuffle_epi32 (data,0x31);
+                __m128i const k2  = _mm_shuffle_epi32 (k,0x31);
+                __m128i const dk2 = _mm_mul_epu32 (d2,k2);           /* U32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+
+                xacc[i] = _mm_xor_si128(dk, dk2);
+        }   }
+    }
+
+#else   /* scalar variant */
+
+          U64* const xacc =       (U64*) acc;
+    const U32* const xkey = (const U32*) key;
+
+    int i;
+    for (i=0; i < (int)ACC_NB; i++) {
+        int const left = 2*i;
+        int const right= 2*i + 1;
+        xacc[i] ^= xacc[i] >> 47;
+        xacc[i] ^= PRIME64_5;
+
+        {   U64 p1 = (xacc[i] >> 32) * xkey[left];
+            U64 p2 = (xacc[i] & 0xFFFFFFFF) * xkey[right];
+            xacc[i] = p1 ^ p2;
+    }   }
+
+#endif
+}
+
+static void XXH3_accumulate(U64* acc, const void* restrict data, const U32* restrict key, size_t nbStripes)
+{
+    size_t n;
+    for (n = 0; n < nbStripes; n++ ) {
+        XXH3_accumulate_512(acc, (const BYTE*)data + n*STRIPE_LEN, key);
+        key += 2;
+    }
+}
+
+
+__attribute__((noinline)) static U64    /* It seems better for XXH3_64b to have hashLong not inlined : may mess up the switch case ? */
+XXH3_hashLong(const void* data, size_t len)
+{
+    ALIGN(64) U64 acc[ACC_NB] = { 0, PRIME64_1, PRIME64_2, PRIME64_3, PRIME64_4, PRIME64_5 };
+
+    #define NB_KEYS ((KEYSET_DEFAULT_SIZE - STRIPE_ELTS) / 2)
+
+    size_t const block_len = STRIPE_LEN * NB_KEYS;
+    size_t const nb_blocks = len / block_len;
+
+    size_t n;
+    for (n = 0; n < nb_blocks; n++) {
+        XXH3_accumulate(acc, (const BYTE*)data + n*block_len, kKey, NB_KEYS);
+        XXH3_scrambleAcc(acc, kKey + (KEYSET_DEFAULT_SIZE - STRIPE_ELTS));
+    }
+
+    /* last partial block */
+    assert(len > STRIPE_LEN);
+    {   size_t const nbStripes = (len % block_len) / STRIPE_LEN;
+        assert(nbStripes < NB_KEYS);
+        XXH3_accumulate(acc, (const BYTE*)data + nb_blocks*block_len, kKey, nbStripes);
+
+        /* last stripe */
+        if (len & (STRIPE_LEN - 1)) {
+            const BYTE* const p = (const BYTE*) data + len - STRIPE_LEN;
+            XXH3_accumulate_512(acc, p, kKey + nbStripes*2);
+    }   }
+
+    /* converge into final hash */
+    return XXH3_finalMerge_8u64(acc[0] + len, acc[1], acc[2], acc[3], acc[4], acc[5], acc[6], acc[7] - len, PRIME64_2 + len*2);
+}
+
+
+
+/* ==========================================
+ * Public entry point
+ * ========================================== */
+
+XXH_PUBLIC_API XXH64_hash_t XXH3_64b(const void* data, size_t len)
+{
+    switch ((len-1) / 16) {  /* intentional underflow */
+        case 0: return XXH3_len_1to16_64b(data, len);
+        case 1: return XXH3_len_17to32_64b(data, len);
+        case 2:
+        case 3: return XXH3_len_33to64_64b(data, len);  /* 33-64 */
+        default:;
+    }
+    if (len==0) return 0;
+    if (len <= 96) return XXH3_len_65to96_64b(data, len);
+    if (len <= 128) return XXH3_len_97to128_64b(data, len);
+    return XXH3_hashLong(data, len);
+}
+
+
+
+#endif  /* XXH3_H */

--- a/xxh3.h
+++ b/xxh3.h
@@ -59,95 +59,11 @@
 
 
 
-/* ==========================================
- * Short keys
- * ========================================== */
-
-static U64 XXH3_mixHigh(U64 val) {
-  return val ^ (val >> 47);
-}
-
-static U64 XXH3_finalMerge_2u64(U64 ll1, U64 ll2, U64 mul)
-{
-    U64 const ll11 = XXH3_mixHigh((ll1 ^ ll2) * mul);
-    U64 const ll21 = XXH3_mixHigh((ll2 ^ ll11) * mul);
-    return ll21 * mul;
-}
-
-static U64 XXH3_finalMerge_8u64(U64 ll1, U64 ll2, U64 ll3, U64 ll4,
-                                U64 ll5, U64 ll6, U64 ll7, U64 ll8,
-                                U64 mul)
-{
-    U64 const ll11 = XXH_rotl64(ll1 + ll7, 21) + (XXH_rotl64(ll2, 34) + ll3) * 9;
-    U64 const ll12 = ((ll1 + ll2) ^ ll4) + ll6 + 1;
-    U64 const ll13 = XXH_rotl64(ll5 + ll6, 22) + ll3;
-    U64 const ll14 = ll5 + XXH_rotl64(ll8, 11) + ll3;
-
-    U64 const ll21 = XXH_swap64((ll11 + ll12) * mul) + ll8;
-    U64 const ll31 = (XXH_swap64((ll12 + ll21) * mul) + ll7) * mul;
-    U64 const ll41 = XXH_swap64((ll13 + ll14) * mul + ll31) + ll2;
-    U64 const ll51 = XXH3_mixHigh((ll14 + ll41) * mul + ll4 + ll8) * mul;
-
-    return ll51 + ll13;
-}
-
-
-XXH_FORCE_INLINE U64 XXH3_len_1to3_64b(const void* data, size_t len)
-{
-    assert(data != NULL);
-    assert(len > 0 && len <= 3);
-    {   BYTE const c1 = ((const BYTE*)data)[0];
-        BYTE const c2 = ((const BYTE*)data)[len >> 1];
-        BYTE const c3 = ((const BYTE*)data)[len - 1];
-        U32  const l1 = (U32)(c1) + ((U32)(c2) << 8);
-        U32  const l2 = (U32)(len) + ((U32)(c3) << 2);
-        U64  const ll3 = (l1 * PRIME64_2) ^ (l2 * PRIME64_1);
-        return XXH3_mixHigh(ll3) * PRIME64_3;
-    }
-}
-
-
-XXH_FORCE_INLINE U64 XXH3_len_4to8_64b(const void* data, size_t len)
-{
-    assert(data != NULL);
-    assert(len >= 4 && len <= 8);
-    {   U64 const mul = PRIME64_2 + (len * 2);  /* keep it odd */
-        U64 const ll1 = XXH_read32(data);
-        U64 const ll2 = XXH_read32((const BYTE*)data + len - 4) + PRIME64_1;
-        return XXH3_finalMerge_2u64((len-1) + (ll1 << 3), ll2, mul);
-    }
-}
-
-XXH_FORCE_INLINE U64 XXH3_len_9to16_64b(const void* data, size_t len)
-{
-    assert(data != NULL);
-    assert(len >= 9 && len <= 16);
-    {   U64 const ll1 = XXH_read64(data) + PRIME64_1;
-        U64 const ll2 = XXH_read64((const BYTE*)data + len - 8);
-        U64 const mul = PRIME64_2 + (len * 2);  /* keep it odd */
-        U64 const ll11 = (ll1 * mul) + XXH_rotl64(ll2, 23);
-        U64 const ll12 = (ll2 * mul) + XXH_rotl64(ll1, 37);
-        return XXH3_finalMerge_2u64(ll11, ll12, mul);
-    }
-}
-
-XXH_FORCE_INLINE U64 XXH3_len_1to16_64b(const void* data, size_t len)
-{
-    assert(data != NULL);
-    assert(len > 0 && len <= 16);
-    {   if (len > 8) return XXH3_len_9to16_64b(data, len);
-        if (len >= 4) return XXH3_len_4to8_64b(data, len);
-        return XXH3_len_1to3_64b(data, len);
-    }
-}
-
 
 /* ==========================================
- * Long keys
+ * XXH3 default settings
  * ========================================== */
 
-#define STRIPE_LEN 64
-#define STRIPE_ELTS (STRIPE_LEN / sizeof(U32))
 #define KEYSET_DEFAULT_SIZE 48   /* minimum 32 */
 
 
@@ -167,6 +83,89 @@ ALIGN(64) static const U32 kKey[KEYSET_DEFAULT_SIZE] = {
     0x45cb3a8f,0x95160428,0xafd7fbca,0xbb4b407e,
 };
 
+XXH_FORCE_INLINE U64
+XXH3_mul128(U64 ll1, U64 ll2)
+{
+  __uint128_t lll = (__uint128_t)ll1 * ll2;
+  return (U64)lll + (lll >> 64);
+}
+
+static U64 XXH64_avalanche2(U64 h64)
+{
+    h64 ^= h64 >> 29;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+    return h64;
+}
+
+/* ==========================================
+ * Short keys
+ * ========================================== */
+XXH_FORCE_INLINE U64
+XXH3_len_1to3_64b(const void* data, size_t len, const void* keyPtr)
+{
+    assert(data != NULL);
+    assert(len > 0 && len <= 3);
+    assert(keyPtr != NULL);
+    {   const U32* const key32 = (const U32*) keyPtr;
+        BYTE const c1 = ((const BYTE*)data)[0];
+        BYTE const c2 = ((const BYTE*)data)[len >> 1];
+        BYTE const c3 = ((const BYTE*)data)[len - 1];
+        U32  const l1 = (U32)(c1) + ((U32)(c2) << 8);
+        U32  const l2 = (U32)(len) + ((U32)(c3) << 2);
+        U64  const ll3 = (U64)(l1 + key32[0]) * (l2 + key32[1]);
+        return XXH64_avalanche2(ll3);
+    }
+}
+
+
+XXH_FORCE_INLINE U64
+XXH3_len_4to8_64b(const void* data, size_t len, const void* keyPtr)
+{
+    assert(data != NULL);
+    assert(len >= 4 && len <= 8);
+    {   const U32* const key32 = (const U32*) keyPtr;
+        U64 acc = PRIME64_1 * len;
+        U64 const l1 = XXH_read32(data) + key32[0];
+        U64 const l2 = XXH_read32((const BYTE*)data + len - 4) + key32[1];
+        acc += (U64)l1 * l2;
+        return XXH64_avalanche2(acc);
+    }
+}
+
+XXH_FORCE_INLINE U64
+XXH3_len_9to16_64b(const void* data, size_t len, const void* keyPtr)
+{
+    assert(data != NULL);
+    assert(key != NULL);
+    assert(len >= 9 && len <= 16);
+    {   const U64* const key64 = (const U64*) keyPtr;
+        U64 acc = PRIME64_1 * len;
+        U64 const ll1 = XXH_read64(data) + key64[0];
+        U64 const ll2 = XXH_read64((const BYTE*)data + len - 8) + key64[1];
+        acc += XXH3_mul128(ll1, ll2);
+        return XXH64_avalanche2(acc);
+    }
+}
+
+XXH_FORCE_INLINE U64 XXH3_len_0to16_64b(const void* data, size_t len)
+{
+    assert(data != NULL);
+    assert(len <= 16);
+    {   if (len > 8) return XXH3_len_9to16_64b(data, len, kKey);
+        if (len >= 4) return XXH3_len_4to8_64b(data, len, kKey);
+        if (len) return XXH3_len_1to3_64b(data, len, kKey);
+        return 0;
+    }
+}
+
+
+/* ==========================================
+ * Long keys
+ * ========================================== */
+
+#define STRIPE_LEN 64
+#define STRIPE_ELTS (STRIPE_LEN / sizeof(U32))
 #define ACC_NB (STRIPE_LEN / sizeof(U64))
 
 XXH_FORCE_INLINE void
@@ -384,8 +383,25 @@ static void XXH3_accumulate(U64* acc, const void* restrict data, const U32* rest
     }
 }
 
+XXH_FORCE_INLINE U64 XXH3_mix16B(const void* data, const U64* key)
+{
+    return XXH3_mul128((XXH_read64(data) ^ key[0]), XXH_read64((const BYTE*)data+8) ^ key[1]);
+}
 
-__attribute__((noinline)) static U64    /* It seems better for XXH3_64b to have hashLong not inlined : may mess up the switch case ? */
+static XXH64_hash_t XXH3_merge64B(const U64* data, const void* keyVoid, U64 len)
+{
+    const U64* const key = (const U64*)keyVoid;  /* presumed aligned */
+
+    U64 acc = PRIME64_1 * len;
+    acc += XXH3_mix16B(data+0, key+0);
+    acc += XXH3_mix16B(data+2, key+2);
+    acc += XXH3_mix16B(data+4, key+4);
+    acc += XXH3_mix16B(data+6, key+6);
+
+    return XXH64_avalanche2(acc);
+}
+
+__attribute__((noinline)) static U64    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
 XXH3_hashLong(const void* data, size_t len)
 {
     ALIGN(64) U64 acc[ACC_NB] = { 0, PRIME64_1, PRIME64_2, PRIME64_3, PRIME64_4, PRIME64_5 };
@@ -414,7 +430,9 @@ XXH3_hashLong(const void* data, size_t len)
     }   }
 
     /* converge into final hash */
-    return XXH3_finalMerge_8u64(acc[0] + len, acc[1], acc[2], acc[3], acc[4], acc[5], acc[6], acc[7] - len, PRIME64_2 + len*2);
+    //return XXH3_finalMerge_8u64(acc[0] + len, acc[1], acc[2], acc[3], acc[4], acc[5], acc[6], acc[7] - len, PRIME64_2 + len*2);
+    assert(sizeof(acc) == 64);
+    return XXH3_merge64B(acc, kKey, len);
 }
 
 
@@ -423,115 +441,37 @@ XXH3_hashLong(const void* data, size_t len)
  * Public entry point
  * ========================================== */
 
-XXH_FORCE_INLINE __attribute__((unused)) U64
-XXH3_mul128(U64 ll1, U64 ll2)
-{
-  __uint128_t lll = (__uint128_t)ll1 * ll2;
-  return (U64)lll + (lll >> 64);
-}
-
-XXH_FORCE_INLINE U64 XXH3_mix16B(const void* data, const U64* key)
-{
-    return XXH3_mul128((XXH_read64(data) ^ key[0]), XXH_read64((const BYTE*)data+8) ^ key[1]);
-}
-
-static U64 XXH64_avalanche2(U64 h64)
-{
-    //h64 ^= h64 >> 33;
-    //h64 *= PRIME64_2;
-    h64 ^= h64 >> 29;
-    h64 *= PRIME64_3;
-    h64 ^= h64 >> 32;
-    return h64;
-}
-
 XXH_PUBLIC_API XXH64_hash_t XXH3_64b(const void* data, size_t len)
 {
-#if 1
-
     const BYTE* const p = (const BYTE*)data;
     const U64* const key = (const U64*)(const void*)kKey;
-    U64 acc = PRIME64_1 * len;
 
-    if (len <= 16) return XXH3_len_1to16_64b(data, len);
+    if (len <= 16) return XXH3_len_0to16_64b(data, len);
 
-    if (len > 32) {
-        if (len > 64) {
-            if (len > 96) {
-                if (len > 128) return XXH3_hashLong(data, len);
+    {   U64 acc = PRIME64_1 * len;
+        if (len > 32) {
+            if (len > 64) {
+                if (len > 96) {
+                    if (len > 128) return XXH3_hashLong(data, len);
 
-                acc += XXH3_mix16B(p+48, key+12);
-                acc += XXH3_mix16B(p+len-64, key+14);
-            }
-
-            acc += XXH3_mix16B(p+32, key+8);
-            acc += XXH3_mix16B(p+len-48, key+10);
-        }
-
-        acc += XXH3_mix16B(p+16, key+4);
-        acc += XXH3_mix16B(p+len-32, key+6);
-
-    }
-
-    acc += XXH3_mix16B(p+0, key+0);
-    acc += XXH3_mix16B(p+len-16, key+2);
-
-    return XXH64_avalanche2(acc);
-
-#else
-
-    const BYTE* const p = (const BYTE*)data;
-    const U64* const key = (const U64*)(const void*)kKey;
-    U64 acc = PRIME64_1 * len;
-
-    if (len <= 16) return XXH3_len_1to16_64b(data, len);
-
-    if (len > 32) {
-        if (len > 64) {
-            if (len > 96) {
-                if (len > 128) return XXH3_hashLong(data, len);
-
-                {   U64 const ll1 = XXH_read64(p + 48);
-                    U64 const ll2 = XXH_read64(p + 56);
-                    U64 const ll3 = XXH_read64(p + len - 64);
-                    U64 const ll4 = XXH_read64(p + len - 56);
-
-                    acc += XXH3_mul128((ll1 ^ key[12]), (ll2 ^ key[13]));
-                    acc += XXH3_mul128((ll3 ^ key[14]), (ll4 ^ key[15]));
+                    acc += XXH3_mix16B(p+48, key+12);
+                    acc += XXH3_mix16B(p+len-64, key+14);
                 }
+
+                acc += XXH3_mix16B(p+32, key+8);
+                acc += XXH3_mix16B(p+len-48, key+10);
             }
 
-            {   U64 const ll1 = XXH_read64(p + 32);
-                U64 const ll2 = XXH_read64(p + 40);
-                U64 const ll3 = XXH_read64(p + len - 48);
-                U64 const ll4 = XXH_read64(p + len - 40);
+            acc += XXH3_mix16B(p+16, key+4);
+            acc += XXH3_mix16B(p+len-32, key+6);
 
-                acc += XXH3_mul128((ll1 ^ key[ 8]), (ll2 ^ key[ 9]));
-                acc += XXH3_mul128((ll3 ^ key[10]), (ll4 ^ key[11]));
-            }
         }
 
-        {   U64 const ll1 = XXH_read64(p + 16);
-            U64 const ll2 = XXH_read64(p + 24);
-            U64 const ll3 = XXH_read64(p + len - 32);
-            U64 const ll4 = XXH_read64(p + len - 24);
+        acc += XXH3_mix16B(p+0, key+0);
+        acc += XXH3_mix16B(p+len-16, key+2);
 
-            acc += XXH3_mul128((ll1 ^ key[ 4]), (ll2 ^ key[ 5]));
-            acc += XXH3_mul128((ll3 ^ key[ 6]), (ll4 ^ key[ 7]));
-        }
+        return XXH64_avalanche2(acc);
     }
-
-    {   U64 const ll1 = XXH_read64(p);
-        U64 const ll2 = XXH_read64(p + 8);
-        U64 const ll3 = XXH_read64(p + len - 16);
-        U64 const ll4 = XXH_read64(p + len -  8);
-
-        acc += XXH3_mul128((ll1 ^ key[0]), (ll2 ^ key[1]));
-        acc += XXH3_mul128((ll3 ^ key[2]), (ll4 ^ key[3]));
-    }
-    return XXH64_avalanche2(acc);
-
-#endif
 }
 
 

--- a/xxhash.c
+++ b/xxhash.c
@@ -1,187 +1,636 @@
 /*
-xxHash - Fast Hash algorithm
-Copyright (C) 2012-2014, Yann Collet.
-Copyright (C) 2012, Maciej Adamczyk
-BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-You can contact the author at :
-- xxHash source repository : http://code.google.com/p/xxhash/
-- public discussion board : https://groups.google.com/forum/#!forum/lz4c
-
-This file contains a super-fast hash function for checksumming
-purposes, designed for large (1 KB++) inputs.
-Known limitations:
-    * they use 64-bit math and will not be so fast on 32-bit machines
-    * on architectures that disallow unaligned memory access, the input
-      must be 8-byte aligned. Aligning it on other architectures
-      is not needed, but will improve performance.
-    * it produces different results on big and small endian.
+*  xxHash - Fast Hash algorithm
+*  Copyright (C) 2012-2016, Yann Collet
+*
+*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are
+*  met:
+*
+*  * Redistributions of source code must retain the above copyright
+*  notice, this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above
+*  copyright notice, this list of conditions and the following disclaimer
+*  in the documentation and/or other materials provided with the
+*  distribution.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*  You can contact the author at :
+*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 
 
-//**************************************
-// Tuning parameters
-//**************************************
-// Unaligned memory access is automatically enabled for "common" CPU, such as x86.
-// For others CPU, the compiler will be more cautious, and insert extra code to ensure aligned access is respected.
-// If you know your target CPU supports unaligned memory access, you want to force this option manually to improve performance.
-// You can also enable this parameter if you know your input data will always be aligned (boundaries of 4, for U32).
-#if defined(__ARM_FEATURE_UNALIGNED) || defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
-#  define XXH_USE_UNALIGNED_ACCESS 1
-#endif
-
-// XXH_ACCEPT_NULL_INPUT_POINTER :
-// If the input pointer is a null pointer, xxHash default behavior is to trigger a memory access error, since it is a bad pointer.
-// When this option is enabled, xxHash output for null input pointers will be the same as a null-length input.
-// This option has a very small performance cost (only measurable on small inputs).
-// By default, this option is disabled. To enable it, uncomment below define :
-// #define XXH_ACCEPT_NULL_INPUT_POINTER 1
-
-// XXH_FORCE_NATIVE_FORMAT :
-// By default, xxHash library provides endian-independant Hash values, based on little-endian convention.
-// Results are therefore identical for little-endian and big-endian CPU.
-// This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
-// Should endian-independance be of no importance for your application, you may set the #define below to 1.
-// It will improve speed for Big-endian CPU.
-// This option has no impact on Little_Endian CPU.
-#define XXH_FORCE_NATIVE_FORMAT 0
-
-//**************************************
-// Compiler Specific Options
-//**************************************
-// Disable some Visual warning messages
-#ifdef _MSC_VER  // Visual Studio
-#  pragma warning(disable : 4127)      // disable: C4127: conditional expression is constant
-#endif
-
-#ifdef _MSC_VER    // Visual Studio
-#  define FORCE_INLINE static __forceinline
-#else
-#  ifdef __GNUC__
-#    define FORCE_INLINE static inline __attribute__((always_inline))
-#  else
-#    define FORCE_INLINE static inline
+/* *************************************
+*  Tuning parameters
+***************************************/
+/*!XXH_FORCE_MEMORY_ACCESS :
+ * By default, access to unaligned memory is controlled by `memcpy()`, which is safe and portable.
+ * Unfortunately, on some target/compiler combinations, the generated assembly is sub-optimal.
+ * The below switch allow to select different access method for improved performance.
+ * Method 0 (default) : use `memcpy()`. Safe and portable.
+ * Method 1 : `__packed` statement. It depends on compiler extension (ie, not portable).
+ *            This method is safe if your compiler supports it, and *generally* as fast or faster than `memcpy`.
+ * Method 2 : direct access. This method doesn't depend on compiler but violate C standard.
+ *            It can generate buggy code on targets which do not support unaligned memory accesses.
+ *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
+ * See http://stackoverflow.com/a/32095106/646947 for details.
+ * Prefer these methods in priority order (0 > 1 > 2)
+ */
+#ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
+#  if defined(__GNUC__) && ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) \
+                        || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) \
+                        || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
+#    define XXH_FORCE_MEMORY_ACCESS 2
+#  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
+  (defined(__GNUC__) && ( defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) \
+                    || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) \
+                    || defined(__ARM_ARCH_7S__) ))
+#    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif
 
-//**************************************
-// Includes & Memory related functions
-//**************************************
-#include "xxhash.h"
-// Modify the local functions below should you wish to use some other memory routines
-// for malloc(), free()
+/*!XXH_ACCEPT_NULL_INPUT_POINTER :
+ * If input pointer is NULL, xxHash default behavior is to dereference it, triggering a segfault.
+ * When this macro is enabled, xxHash actively checks input for null pointer.
+ * It it is, result for null input pointers is the same as a null-length input.
+ */
+#ifndef XXH_ACCEPT_NULL_INPUT_POINTER   /* can be defined externally */
+#  define XXH_ACCEPT_NULL_INPUT_POINTER 0
+#endif
+
+/*!XXH_FORCE_NATIVE_FORMAT :
+ * By default, xxHash library provides endian-independent Hash values, based on little-endian convention.
+ * Results are therefore identical for little-endian and big-endian CPU.
+ * This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
+ * Should endian-independence be of no importance for your application, you may set the #define below to 1,
+ * to improve speed for Big-endian CPU.
+ * This option has no impact on Little_Endian CPU.
+ */
+#ifndef XXH_FORCE_NATIVE_FORMAT   /* can be defined externally */
+#  define XXH_FORCE_NATIVE_FORMAT 0
+#endif
+
+/*!XXH_FORCE_ALIGN_CHECK :
+ * This is a minor performance trick, only useful with lots of very small keys.
+ * It means : check for aligned/unaligned input.
+ * The check costs one initial branch per hash;
+ * set it to 0 when the input is guaranteed to be aligned,
+ * or when alignment doesn't matter for performance.
+ */
+#ifndef XXH_FORCE_ALIGN_CHECK /* can be defined externally */
+#  if defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+#    define XXH_FORCE_ALIGN_CHECK 0
+#  else
+#    define XXH_FORCE_ALIGN_CHECK 1
+#  endif
+#endif
+
+
+/* *************************************
+*  Includes & Memory related functions
+***************************************/
+/*! Modify the local functions below should you wish to use some other memory routines
+*   for malloc(), free() */
 #include <stdlib.h>
 static void* XXH_malloc(size_t s) { return malloc(s); }
 static void  XXH_free  (void* p)  { free(p); }
-// for memcpy()
+/*! and for memcpy() */
 #include <string.h>
-static void* XXH_memcpy(void* dest, const void* src, size_t size)
+static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcpy(dest,src,size); }
+
+#include <assert.h>   /* assert */
+
+#define XXH_STATIC_LINKING_ONLY
+#include "xxhash.h"
+
+
+/* *************************************
+*  Compiler Specific Options
+***************************************/
+#ifdef _MSC_VER    /* Visual Studio */
+#  pragma warning(disable : 4127)      /* disable: C4127: conditional expression is constant */
+#  define XXH_FORCE_INLINE static __forceinline
+#else
+#  if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+#    ifdef __GNUC__
+#      define XXH_FORCE_INLINE static inline __attribute__((always_inline))
+#    else
+#      define XXH_FORCE_INLINE static inline
+#    endif
+#  else
+#    define XXH_FORCE_INLINE static
+#  endif /* __STDC_VERSION__ */
+#endif
+
+
+/* *************************************
+*  Basic Types
+***************************************/
+#ifndef MEM_MODULE
+# if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint8_t  BYTE;
+    typedef uint16_t U16;
+    typedef uint32_t U32;
+# else
+    typedef unsigned char      BYTE;
+    typedef unsigned short     U16;
+    typedef unsigned int       U32;
+# endif
+#endif
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
+static U32 XXH_read32(const void* memPtr) { return *(const U32*) memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+typedef union { U32 u32; } __attribute__((packed)) unalign;
+static U32 XXH_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+static U32 XXH_read32(const void* memPtr)
 {
-    return memcpy(dest,src,size);
+    U32 val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
-
-//**************************************
-// Basic Types
-//**************************************
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   // C99
-# include <stdint.h>
-typedef uint8_t  BYTE;
-typedef uint16_t U16;
-typedef uint32_t U32;
-typedef  int32_t S32;
-typedef uint64_t U64;
-#else
-typedef unsigned char      BYTE;
-typedef unsigned short     U16;
-typedef unsigned int       U32;
-typedef   signed int       S32;
-typedef unsigned long long U64;
-#endif
-
-#if defined(__GNUC__)  && !defined(XXH_USE_UNALIGNED_ACCESS)
-#  define _PACKED __attribute__ ((packed))
-#else
-#  define _PACKED
-#endif
-
-#if !defined(XXH_USE_UNALIGNED_ACCESS) && !defined(__GNUC__)
-#  ifdef __IBMC__
-#    pragma pack(1)
-#  else
-#    pragma pack(push, 1)
-#  endif
-#endif
-
-typedef struct _U32_S
-{
-    U32 v;
-} _PACKED U32_S;
-typedef struct _U64_S
-{
-    U64 v;
-} _PACKED U64_S;
-
-#if !defined(XXH_USE_UNALIGNED_ACCESS) && !defined(__GNUC__)
-#  pragma pack(pop)
-#endif
-
-#define A32(x) (((U32_S *)(x))->v)
-#define A64(x) (((U64_S *)(x))->v)
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
 
 
-//***************************************
-// Compiler-specific Functions and Macros
-//***************************************
-#define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+/* ****************************************
+*  Compiler-specific Functions and Macros
+******************************************/
+#define XXH_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 
-// Note : although _rotl exists for minGW (GCC under windows), performance seems poor
+/* Note : although _rotl exists for minGW (GCC under windows), performance seems poor */
 #if defined(_MSC_VER)
 #  define XXH_rotl32(x,r) _rotl(x,r)
 #  define XXH_rotl64(x,r) _rotl64(x,r)
 #else
-#  define XXH_rotl32(x,r) ((x << r) | (x >> (32 - r)))
-#  define XXH_rotl64(x,r) ((x << r) | (x >> (64 - r)))
+#  define XXH_rotl32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
+#  define XXH_rotl64(x,r) (((x) << (r)) | ((x) >> (64 - (r))))
 #endif
 
-#if defined(_MSC_VER)     // Visual Studio
+#if defined(_MSC_VER)     /* Visual Studio */
 #  define XXH_swap32 _byteswap_ulong
-#  define XXH_swap64 _byteswap_uint64
-#elif GCC_VERSION >= 403
+#elif XXH_GCC_VERSION >= 403
 #  define XXH_swap32 __builtin_bswap32
-#  define XXH_swap64 __builtin_bswap64
 #else
-static inline U32 XXH_swap32 (U32 x)
+static U32 XXH_swap32 (U32 x)
 {
     return  ((x << 24) & 0xff000000 ) |
             ((x <<  8) & 0x00ff0000 ) |
             ((x >>  8) & 0x0000ff00 ) |
             ((x >> 24) & 0x000000ff );
 }
-static inline U64 XXH_swap64 (U64 x)
+#endif
+
+
+/* *************************************
+*  Architecture Macros
+***************************************/
+typedef enum { XXH_bigEndian=0, XXH_littleEndian=1 } XXH_endianess;
+
+/* XXH_CPU_LITTLE_ENDIAN can be defined externally, for example on the compiler command line */
+#ifndef XXH_CPU_LITTLE_ENDIAN
+static int XXH_isLittleEndian(void)
+{
+    const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental  */
+    return one.c[0];
+}
+#   define XXH_CPU_LITTLE_ENDIAN   XXH_isLittleEndian()
+#endif
+
+
+/* ***************************
+*  Memory reads
+*****************************/
+typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
+
+XXH_FORCE_INLINE U32
+XXH_readLE32_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return endian==XXH_littleEndian ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+    else
+        return endian==XXH_littleEndian ? *(const U32*)ptr : XXH_swap32(*(const U32*)ptr);
+}
+
+XXH_FORCE_INLINE U32 XXH_readLE32(const void* ptr, XXH_endianess endian)
+{
+    return XXH_readLE32_align(ptr, endian, XXH_unaligned);
+}
+
+static U32 XXH_readBE32(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
+}
+
+
+/* *************************************
+*  Macros
+***************************************/
+#define XXH_STATIC_ASSERT(c)  { enum { XXH_sa = 1/(int)(!!(c)) }; }  /* use after variable declarations */
+XXH_PUBLIC_API unsigned XXH_versionNumber (void) { return XXH_VERSION_NUMBER; }
+
+
+/* *******************************************************************
+*  32-bit hash functions
+*********************************************************************/
+static const U32 PRIME32_1 = 2654435761U;   /* 0b10011110001101110111100110110001 */
+static const U32 PRIME32_2 = 2246822519U;   /* 0b10000101111010111100101001110111 */
+static const U32 PRIME32_3 = 3266489917U;   /* 0b11000010101100101010111000111101 */
+static const U32 PRIME32_4 =  668265263U;   /* 0b00100111110101001110101100101111 */
+static const U32 PRIME32_5 =  374761393U;   /* 0b00010110010101100110011110110001 */
+
+static U32 XXH32_round(U32 seed, U32 input)
+{
+    seed += input * PRIME32_2;
+    seed  = XXH_rotl32(seed, 13);
+    seed *= PRIME32_1;
+    return seed;
+}
+
+/* mix all bits */
+static U32 XXH32_avalanche(U32 h32)
+{
+    h32 ^= h32 >> 15;
+    h32 *= PRIME32_2;
+    h32 ^= h32 >> 13;
+    h32 *= PRIME32_3;
+    h32 ^= h32 >> 16;
+    return(h32);
+}
+
+#define XXH_get32bits(p) XXH_readLE32_align(p, endian, align)
+
+static U32
+XXH32_finalize(U32 h32, const void* ptr, size_t len,
+                XXH_endianess endian, XXH_alignment align)
+
+{
+    const BYTE* p = (const BYTE*)ptr;
+
+#define PROCESS1               \
+    h32 += (*p++) * PRIME32_5; \
+    h32 = XXH_rotl32(h32, 11) * PRIME32_1 ;
+
+#define PROCESS4                         \
+    h32 += XXH_get32bits(p) * PRIME32_3; \
+    p+=4;                                \
+    h32  = XXH_rotl32(h32, 17) * PRIME32_4 ;
+
+    switch(len&15)  /* or switch(bEnd - p) */
+    {
+      case 12:      PROCESS4;
+                    /* fallthrough */
+      case 8:       PROCESS4;
+                    /* fallthrough */
+      case 4:       PROCESS4;
+                    return XXH32_avalanche(h32);
+
+      case 13:      PROCESS4;
+                    /* fallthrough */
+      case 9:       PROCESS4;
+                    /* fallthrough */
+      case 5:       PROCESS4;
+                    PROCESS1;
+                    return XXH32_avalanche(h32);
+
+      case 14:      PROCESS4;
+                    /* fallthrough */
+      case 10:      PROCESS4;
+                    /* fallthrough */
+      case 6:       PROCESS4;
+                    PROCESS1;
+                    PROCESS1;
+                    return XXH32_avalanche(h32);
+
+      case 15:      PROCESS4;
+                    /* fallthrough */
+      case 11:      PROCESS4;
+                    /* fallthrough */
+      case 7:       PROCESS4;
+                    /* fallthrough */
+      case 3:       PROCESS1;
+                    /* fallthrough */
+      case 2:       PROCESS1;
+                    /* fallthrough */
+      case 1:       PROCESS1;
+                    /* fallthrough */
+      case 0:       return XXH32_avalanche(h32);
+    }
+    assert(0);
+    return h32;   /* reaching this point is deemed impossible */
+}
+
+
+XXH_FORCE_INLINE U32
+XXH32_endian_align(const void* input, size_t len, U32 seed,
+                    XXH_endianess endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U32 h32;
+
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+    if (p==NULL) {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)16;
+    }
+#endif
+
+    if (len>=16) {
+        const BYTE* const limit = bEnd - 15;
+        U32 v1 = seed + PRIME32_1 + PRIME32_2;
+        U32 v2 = seed + PRIME32_2;
+        U32 v3 = seed + 0;
+        U32 v4 = seed - PRIME32_1;
+
+        do {
+            v1 = XXH32_round(v1, XXH_get32bits(p)); p+=4;
+            v2 = XXH32_round(v2, XXH_get32bits(p)); p+=4;
+            v3 = XXH32_round(v3, XXH_get32bits(p)); p+=4;
+            v4 = XXH32_round(v4, XXH_get32bits(p)); p+=4;
+        } while (p < limit);
+
+        h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
+            + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+    } else {
+        h32  = seed + PRIME32_5;
+    }
+
+    h32 += (U32)len;
+
+    return XXH32_finalize(h32, p, len&15, endian, align);
+}
+
+
+XXH_PUBLIC_API unsigned int XXH32 (const void* input, size_t len, unsigned int seed)
+{
+#if 0
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH32_state_t state;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, input, len);
+    return XXH32_digest(&state);
+#else
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 3) == 0) {   /* Input is 4-bytes aligned, leverage the speed benefit */
+            if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+                return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+            else
+                return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }   }
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
+    else
+        return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
+#endif
+}
+
+
+
+/*======   Hash streaming   ======*/
+
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void)
+{
+    return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
+}
+XXH_PUBLIC_API XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dstState, const XXH32_state_t* srcState)
+{
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, unsigned int seed)
+{
+    XXH32_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
+    memset(&state, 0, sizeof(state));
+    state.v1 = seed + PRIME32_1 + PRIME32_2;
+    state.v2 = seed + PRIME32_2;
+    state.v3 = seed + 0;
+    state.v4 = seed - PRIME32_1;
+    /* do not write into reserved, planned to be removed in a future version */
+    memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved));
+    return XXH_OK;
+}
+
+
+XXH_FORCE_INLINE XXH_errorcode
+XXH32_update_endian(XXH32_state_t* state, const void* input, size_t len, XXH_endianess endian)
+{
+    if (input==NULL)
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+        return XXH_OK;
+#else
+        return XXH_ERROR;
+#endif
+
+    {   const BYTE* p = (const BYTE*)input;
+        const BYTE* const bEnd = p + len;
+
+        state->total_len_32 += (unsigned)len;
+        state->large_len |= (len>=16) | (state->total_len_32>=16);
+
+        if (state->memsize + len < 16)  {   /* fill in tmp buffer */
+            XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);
+            state->memsize += (unsigned)len;
+            return XXH_OK;
+        }
+
+        if (state->memsize) {   /* some data left from previous update */
+            XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, 16-state->memsize);
+            {   const U32* p32 = state->mem32;
+                state->v1 = XXH32_round(state->v1, XXH_readLE32(p32, endian)); p32++;
+                state->v2 = XXH32_round(state->v2, XXH_readLE32(p32, endian)); p32++;
+                state->v3 = XXH32_round(state->v3, XXH_readLE32(p32, endian)); p32++;
+                state->v4 = XXH32_round(state->v4, XXH_readLE32(p32, endian));
+            }
+            p += 16-state->memsize;
+            state->memsize = 0;
+        }
+
+        if (p <= bEnd-16) {
+            const BYTE* const limit = bEnd - 16;
+            U32 v1 = state->v1;
+            U32 v2 = state->v2;
+            U32 v3 = state->v3;
+            U32 v4 = state->v4;
+
+            do {
+                v1 = XXH32_round(v1, XXH_readLE32(p, endian)); p+=4;
+                v2 = XXH32_round(v2, XXH_readLE32(p, endian)); p+=4;
+                v3 = XXH32_round(v3, XXH_readLE32(p, endian)); p+=4;
+                v4 = XXH32_round(v4, XXH_readLE32(p, endian)); p+=4;
+            } while (p<=limit);
+
+            state->v1 = v1;
+            state->v2 = v2;
+            state->v3 = v3;
+            state->v4 = v4;
+        }
+
+        if (p < bEnd) {
+            XXH_memcpy(state->mem32, p, (size_t)(bEnd-p));
+            state->memsize = (unsigned)(bEnd-p);
+        }
+    }
+
+    return XXH_OK;
+}
+
+
+XXH_PUBLIC_API XXH_errorcode XXH32_update (XXH32_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH32_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+
+XXH_FORCE_INLINE U32
+XXH32_digest_endian (const XXH32_state_t* state, XXH_endianess endian)
+{
+    U32 h32;
+
+    if (state->large_len) {
+        h32 = XXH_rotl32(state->v1, 1)
+            + XXH_rotl32(state->v2, 7)
+            + XXH_rotl32(state->v3, 12)
+            + XXH_rotl32(state->v4, 18);
+    } else {
+        h32 = state->v3 /* == seed */ + PRIME32_5;
+    }
+
+    h32 += state->total_len_32;
+
+    return XXH32_finalize(h32, state->mem32, state->memsize, endian, XXH_aligned);
+}
+
+
+XXH_PUBLIC_API unsigned int XXH32_digest (const XXH32_state_t* state_in)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_digest_endian(state_in, XXH_littleEndian);
+    else
+        return XXH32_digest_endian(state_in, XXH_bigEndian);
+}
+
+
+/*======   Canonical representation   ======*/
+
+/*! Default XXH result types are basic unsigned 32 and 64 bits.
+*   The canonical representation follows human-readable write convention, aka big-endian (large digits first).
+*   These functions allow transformation of hash result into and from its canonical format.
+*   This way, hash values can be written into a file or buffer, remaining comparable across different systems.
+*/
+
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH32_canonical_t) == sizeof(XXH32_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap32(hash);
+    memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src)
+{
+    return XXH_readBE32(src);
+}
+
+
+#ifndef XXH_NO_LONG_LONG
+
+/* *******************************************************************
+*  64-bit hash functions
+*********************************************************************/
+
+/*======   Memory access   ======*/
+
+#ifndef MEM_MODULE
+# define MEM_MODULE
+# if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint64_t U64;
+# else
+    /* if compiler doesn't support unsigned long long, replace by another 64-bit type */
+    typedef unsigned long long U64;
+# endif
+#endif
+
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
+static U64 XXH_read64(const void* memPtr) { return *(const U64*) memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+typedef union { U32 u32; U64 u64; } __attribute__((packed)) unalign64;
+static U64 XXH_read64(const void* ptr) { return ((const unalign64*)ptr)->u64; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+
+static U64 XXH_read64(const void* memPtr)
+{
+    U64 val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
+
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+#if defined(_MSC_VER)     /* Visual Studio */
+#  define XXH_swap64 _byteswap_uint64
+#elif XXH_GCC_VERSION >= 403
+#  define XXH_swap64 __builtin_bswap64
+#else
+static U64 XXH_swap64 (U64 x)
 {
     return  ((x << 56) & 0xff00000000000000ULL) |
             ((x << 40) & 0x00ff000000000000ULL) |
@@ -194,294 +643,221 @@ static inline U64 XXH_swap64 (U64 x)
 }
 #endif
 
-
-//**************************************
-// Constants
-//**************************************
-#define PRIME32_1   2654435761U
-#define PRIME32_2   2246822519U
-#define PRIME32_3   3266489917U
-#define PRIME32_4    668265263U
-#define PRIME32_5    374761393U
-
-#define PRIME64_1 11400714785074694791ULL
-#define PRIME64_2 14029467366897019727ULL
-#define PRIME64_3  1609587929392839161ULL
-#define PRIME64_4  9650029242287828579ULL
-#define PRIME64_5  2870177450012600261ULL
-
-//**************************************
-// Architecture Macros
-//**************************************
-typedef enum { XXH_bigEndian=0, XXH_littleEndian=1 } XXH_endianess;
-#ifndef XXH_CPU_LITTLE_ENDIAN   // It is possible to define XXH_CPU_LITTLE_ENDIAN externally, for example using a compiler switch
-static const int one = 1;
-#   define XXH_CPU_LITTLE_ENDIAN   (*(char*)(&one))
-#endif
-
-
-//**************************************
-// Macros
-//**************************************
-#define XXH_STATIC_ASSERT(c)   { enum { XXH_static_assert = 1/(!!(c)) }; }    // use only *after* variable declarations
-
-
-//****************************
-// Memory reads
-//****************************
-typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
-
-FORCE_INLINE U32 XXH_readLE32_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
+XXH_FORCE_INLINE U64
+XXH_readLE64_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
 {
     if (align==XXH_unaligned)
-        return endian==XXH_littleEndian ? A32(ptr) : XXH_swap32(A32(ptr));
+        return endian==XXH_littleEndian ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
     else
-        return endian==XXH_littleEndian ? *(U32*)ptr : XXH_swap32(*(U32*)ptr);
+        return endian==XXH_littleEndian ? *(const U64*)ptr : XXH_swap64(*(const U64*)ptr);
 }
 
-FORCE_INLINE U32 XXH_readLE32(const void* ptr, XXH_endianess endian)
-{
-    return XXH_readLE32_align(ptr, endian, XXH_unaligned);
-}
-
-FORCE_INLINE U64 XXH_readLE64_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
-{
-    if (align==XXH_unaligned)
-        return endian==XXH_littleEndian ? A64(ptr) : XXH_swap64(A64(ptr));
-    else
-        return endian==XXH_littleEndian ? *(U64*)ptr : XXH_swap64(*(U64*)ptr);
-}
-
-FORCE_INLINE U64 XXH_readLE64(const void* ptr, XXH_endianess endian)
+XXH_FORCE_INLINE U64 XXH_readLE64(const void* ptr, XXH_endianess endian)
 {
     return XXH_readLE64_align(ptr, endian, XXH_unaligned);
 }
 
-
-//****************************
-// Simple Hash Functions
-//****************************
-FORCE_INLINE U32 XXH32_endian_align(const void* input, size_t len, U32 seed, XXH_endianess endian, XXH_alignment align)
+static U64 XXH_readBE64(const void* ptr)
 {
-    const BYTE* p = (const BYTE*)input;
-    const BYTE* bEnd = p + len;
-    U32 h32;
-#define XXH_get32bits(p) XXH_readLE32_align(p, endian, align)
-
-#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
-    if (p==NULL)
-    {
-        len=0;
-        bEnd=p=(const BYTE*)(size_t)16;
-    }
-#endif
-
-    if (len>=16)
-    {
-        const BYTE* const limit = bEnd - 16;
-        U32 v1 = seed + PRIME32_1 + PRIME32_2;
-        U32 v2 = seed + PRIME32_2;
-        U32 v3 = seed + 0;
-        U32 v4 = seed - PRIME32_1;
-
-        do
-        {
-            v1 += XXH_get32bits(p) * PRIME32_2;
-            v1 = XXH_rotl32(v1, 13);
-            v1 *= PRIME32_1;
-            p+=4;
-            v2 += XXH_get32bits(p) * PRIME32_2;
-            v2 = XXH_rotl32(v2, 13);
-            v2 *= PRIME32_1;
-            p+=4;
-            v3 += XXH_get32bits(p) * PRIME32_2;
-            v3 = XXH_rotl32(v3, 13);
-            v3 *= PRIME32_1;
-            p+=4;
-            v4 += XXH_get32bits(p) * PRIME32_2;
-            v4 = XXH_rotl32(v4, 13);
-            v4 *= PRIME32_1;
-            p+=4;
-        }
-        while (p<=limit);
-
-        h32 = XXH_rotl32(v1, 1) + XXH_rotl32(v2, 7) + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
-    }
-    else
-    {
-        h32  = seed + PRIME32_5;
-    }
-
-    h32 += (U32) len;
-
-    while (p+4<=bEnd)
-    {
-        h32 += XXH_get32bits(p) * PRIME32_3;
-        h32  = XXH_rotl32(h32, 17) * PRIME32_4 ;
-        p+=4;
-    }
-
-    while (p<bEnd)
-    {
-        h32 += (*p) * PRIME32_5;
-        h32 = XXH_rotl32(h32, 11) * PRIME32_1 ;
-        p++;
-    }
-
-    h32 ^= h32 >> 15;
-    h32 *= PRIME32_2;
-    h32 ^= h32 >> 13;
-    h32 *= PRIME32_3;
-    h32 ^= h32 >> 16;
-
-    return h32;
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
 }
 
 
-unsigned int XXH32 (const void* input, size_t len, unsigned seed)
+/*======   xxh64   ======*/
+
+static const U64 PRIME64_1 = 11400714785074694791ULL;   /* 0b1001111000110111011110011011000110000101111010111100101010000111 */
+static const U64 PRIME64_2 = 14029467366897019727ULL;   /* 0b1100001010110010101011100011110100100111110101001110101101001111 */
+static const U64 PRIME64_3 =  1609587929392839161ULL;   /* 0b0001011001010110011001111011000110011110001101110111100111111001 */
+static const U64 PRIME64_4 =  9650029242287828579ULL;   /* 0b1000010111101011110010100111011111000010101100101010111001100011 */
+static const U64 PRIME64_5 =  2870177450012600261ULL;   /* 0b0010011111010100111010110010111100010110010101100110011111000101 */
+
+static U64 XXH64_round(U64 acc, U64 input)
 {
-#if 0
-    // Simple version, good for code maintenance, but unfortunately slow for small inputs
-    XXH32_state_t state;
-    XXH32_reset(&state, seed);
-    XXH32_update(&state, input, len);
-    return XXH32_digest(&state);
-#else
-    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
-
-#  if !defined(XXH_USE_UNALIGNED_ACCESS)
-    if ((((size_t)input) & 3) == 0)   // Input is aligned, let's leverage the speed advantage
-    {
-        if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
-            return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
-        else
-            return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
-    }
-#  endif
-
-    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
-        return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
-    else
-        return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
-#endif
+    acc += input * PRIME64_2;
+    acc  = XXH_rotl64(acc, 31);
+    acc *= PRIME64_1;
+    return acc;
 }
 
-FORCE_INLINE U64 XXH64_endian_align(const void* input, size_t len, U64 seed, XXH_endianess endian, XXH_alignment align)
+static U64 XXH64_mergeRound(U64 acc, U64 val)
+{
+    val  = XXH64_round(0, val);
+    acc ^= val;
+    acc  = acc * PRIME64_1 + PRIME64_4;
+    return acc;
+}
+
+static U64 XXH64_avalanche(U64 h64)
+{
+    h64 ^= h64 >> 33;
+    h64 *= PRIME64_2;
+    h64 ^= h64 >> 29;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+    return h64;
+}
+
+
+#define XXH_get64bits(p) XXH_readLE64_align(p, endian, align)
+
+static U64
+XXH64_finalize(U64 h64, const void* ptr, size_t len,
+               XXH_endianess endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)ptr;
+
+#define PROCESS1_64            \
+    h64 ^= (*p++) * PRIME64_5; \
+    h64 = XXH_rotl64(h64, 11) * PRIME64_1;
+
+#define PROCESS4_64          \
+    h64 ^= (U64)(XXH_get32bits(p)) * PRIME64_1; \
+    p+=4;                    \
+    h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
+
+#define PROCESS8_64 {        \
+    U64 const k1 = XXH64_round(0, XXH_get64bits(p)); \
+    p+=8;                    \
+    h64 ^= k1;               \
+    h64  = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4; \
+}
+
+    switch(len&31) {
+      case 24: PROCESS8_64;
+                    /* fallthrough */
+      case 16: PROCESS8_64;
+                    /* fallthrough */
+      case  8: PROCESS8_64;
+               return XXH64_avalanche(h64);
+
+      case 28: PROCESS8_64;
+                    /* fallthrough */
+      case 20: PROCESS8_64;
+                    /* fallthrough */
+      case 12: PROCESS8_64;
+                    /* fallthrough */
+      case  4: PROCESS4_64;
+               return XXH64_avalanche(h64);
+
+      case 25: PROCESS8_64;
+                    /* fallthrough */
+      case 17: PROCESS8_64;
+                    /* fallthrough */
+      case  9: PROCESS8_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 29: PROCESS8_64;
+                    /* fallthrough */
+      case 21: PROCESS8_64;
+                    /* fallthrough */
+      case 13: PROCESS8_64;
+                    /* fallthrough */
+      case  5: PROCESS4_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 26: PROCESS8_64;
+                    /* fallthrough */
+      case 18: PROCESS8_64;
+                    /* fallthrough */
+      case 10: PROCESS8_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 30: PROCESS8_64;
+                    /* fallthrough */
+      case 22: PROCESS8_64;
+                    /* fallthrough */
+      case 14: PROCESS8_64;
+                    /* fallthrough */
+      case  6: PROCESS4_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 27: PROCESS8_64;
+                    /* fallthrough */
+      case 19: PROCESS8_64;
+                    /* fallthrough */
+      case 11: PROCESS8_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 31: PROCESS8_64;
+                    /* fallthrough */
+      case 23: PROCESS8_64;
+                    /* fallthrough */
+      case 15: PROCESS8_64;
+                    /* fallthrough */
+      case  7: PROCESS4_64;
+                    /* fallthrough */
+      case  3: PROCESS1_64;
+                    /* fallthrough */
+      case  2: PROCESS1_64;
+                    /* fallthrough */
+      case  1: PROCESS1_64;
+                    /* fallthrough */
+      case  0: return XXH64_avalanche(h64);
+    }
+
+    /* impossible to reach */
+    assert(0);
+    return 0;  /* unreachable, but some compilers complain without it */
+}
+
+XXH_FORCE_INLINE U64
+XXH64_endian_align(const void* input, size_t len, U64 seed,
+                XXH_endianess endian, XXH_alignment align)
 {
     const BYTE* p = (const BYTE*)input;
     const BYTE* bEnd = p + len;
     U64 h64;
-#define XXH_get64bits(p) XXH_readLE64_align(p, endian, align)
 
-#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
-    if (p==NULL)
-    {
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+    if (p==NULL) {
         len=0;
         bEnd=p=(const BYTE*)(size_t)32;
     }
 #endif
 
-    if (len>=32)
-    {
+    if (len>=32) {
         const BYTE* const limit = bEnd - 32;
         U64 v1 = seed + PRIME64_1 + PRIME64_2;
         U64 v2 = seed + PRIME64_2;
         U64 v3 = seed + 0;
         U64 v4 = seed - PRIME64_1;
 
-        do
-        {
-            v1 += XXH_get64bits(p) * PRIME64_2;
-            p+=8;
-            v1 = XXH_rotl64(v1, 31);
-            v1 *= PRIME64_1;
-            v2 += XXH_get64bits(p) * PRIME64_2;
-            p+=8;
-            v2 = XXH_rotl64(v2, 31);
-            v2 *= PRIME64_1;
-            v3 += XXH_get64bits(p) * PRIME64_2;
-            p+=8;
-            v3 = XXH_rotl64(v3, 31);
-            v3 *= PRIME64_1;
-            v4 += XXH_get64bits(p) * PRIME64_2;
-            p+=8;
-            v4 = XXH_rotl64(v4, 31);
-            v4 *= PRIME64_1;
-        }
-        while (p<=limit);
+        do {
+            v1 = XXH64_round(v1, XXH_get64bits(p)); p+=8;
+            v2 = XXH64_round(v2, XXH_get64bits(p)); p+=8;
+            v3 = XXH64_round(v3, XXH_get64bits(p)); p+=8;
+            v4 = XXH64_round(v4, XXH_get64bits(p)); p+=8;
+        } while (p<=limit);
 
         h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
 
-        v1 *= PRIME64_2;
-        v1 = XXH_rotl64(v1, 31);
-        v1 *= PRIME64_1;
-        h64 ^= v1;
-        h64 = h64 * PRIME64_1 + PRIME64_4;
-
-        v2 *= PRIME64_2;
-        v2 = XXH_rotl64(v2, 31);
-        v2 *= PRIME64_1;
-        h64 ^= v2;
-        h64 = h64 * PRIME64_1 + PRIME64_4;
-
-        v3 *= PRIME64_2;
-        v3 = XXH_rotl64(v3, 31);
-        v3 *= PRIME64_1;
-        h64 ^= v3;
-        h64 = h64 * PRIME64_1 + PRIME64_4;
-
-        v4 *= PRIME64_2;
-        v4 = XXH_rotl64(v4, 31);
-        v4 *= PRIME64_1;
-        h64 ^= v4;
-        h64 = h64 * PRIME64_1 + PRIME64_4;
-    }
-    else
-    {
+    } else {
         h64  = seed + PRIME64_5;
     }
 
     h64 += (U64) len;
 
-    while (p+8<=bEnd)
-    {
-        U64 k1 = XXH_get64bits(p);
-        k1 *= PRIME64_2;
-        k1 = XXH_rotl64(k1,31);
-        k1 *= PRIME64_1;
-        h64 ^= k1;
-        h64 = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4;
-        p+=8;
-    }
-
-    if (p+4<=bEnd)
-    {
-        h64 ^= (U64)(XXH_get32bits(p)) * PRIME64_1;
-        h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
-        p+=4;
-    }
-
-    while (p<bEnd)
-    {
-        h64 ^= (*p) * PRIME64_5;
-        h64 = XXH_rotl64(h64, 11) * PRIME64_1;
-        p++;
-    }
-
-    h64 ^= h64 >> 33;
-    h64 *= PRIME64_2;
-    h64 ^= h64 >> 29;
-    h64 *= PRIME64_3;
-    h64 ^= h64 >> 32;
-
-    return h64;
+    return XXH64_finalize(h64, p, len, endian, align);
 }
 
 
-unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
+XXH_PUBLIC_API unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
 {
 #if 0
-    // Simple version, good for code maintenance, but unfortunately slow for small inputs
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
     XXH64_state_t state;
     XXH64_reset(&state, seed);
     XXH64_update(&state, input, len);
@@ -489,15 +865,13 @@ unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed
 #else
     XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
 
-#  if !defined(XXH_USE_UNALIGNED_ACCESS)
-    if ((((size_t)input) & 7)==0)   // Input is aligned, let's leverage the speed advantage
-    {
-        if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
-            return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
-        else
-            return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
-    }
-#  endif
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 7)==0) {  /* Input is aligned, let's leverage the speed advantage */
+            if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+                return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+            else
+                return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }   }
 
     if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
         return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
@@ -506,391 +880,97 @@ unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed
 #endif
 }
 
-/* Simplier, older variant added by m^2 Maciej Adamczyk. Unportable */
-void XXH_256(const void* input, size_t len, U64* out)
-{
-    const BYTE* p = (BYTE*)input;
-    const BYTE* const bEnd = p + len;
-    U64 v1 = len * PRIME64_1;
-    U64 v2 = v1;
-    U64 v3 = v1;
-    U64 v4 = v1;
- 
-    const size_t big_loop_step = 4 * 4 * sizeof(U64);
-    const size_t small_loop_step = 4 * sizeof(U64);
-    // Set the big loop limit early enough, so the well-mixing small loop can be executed twice after it
-    const BYTE* const big_loop_limit   = bEnd - big_loop_step - 2 * small_loop_step;
-    const BYTE* const small_loop_limit = bEnd - small_loop_step;
- 
-    while (p < big_loop_limit)
-    {
-        v1 = XXH_rotl64(v1, 29) + (*(U64*)p); p+=sizeof(U64);
-        v2 = XXH_rotl64(v2, 31) + (*(U64*)p); p+=sizeof(U64);
-        v3 = XXH_rotl64(v3, 33) + (*(U64*)p); p+=sizeof(U64);
-        v4 = XXH_rotl64(v4, 35) + (*(U64*)p); p+=sizeof(U64);
-        v1 += v2 *= PRIME64_1;
-        v1 = XXH_rotl64(v1, 29) + (*(U64*)p); p+=sizeof(U64);
-        v2 = XXH_rotl64(v2, 31) + (*(U64*)p); p+=sizeof(U64);
-        v3 = XXH_rotl64(v3, 33) + (*(U64*)p); p+=sizeof(U64);
-        v4 = XXH_rotl64(v4, 35) + (*(U64*)p); p+=sizeof(U64);
-        v2 += v3 *= PRIME64_1;
-        v1 = XXH_rotl64(v1, 29) + (*(U64*)p); p+=sizeof(U64);
-        v2 = XXH_rotl64(v2, 31) + (*(U64*)p); p+=sizeof(U64);
-        v3 = XXH_rotl64(v3, 33) + (*(U64*)p); p+=sizeof(U64);
-        v4 = XXH_rotl64(v4, 35) + (*(U64*)p); p+=sizeof(U64);
-        v3 += v4 *= PRIME64_1;
-        v1 = XXH_rotl64(v1, 29) + (*(U64*)p); p+=sizeof(U64);
-        v2 = XXH_rotl64(v2, 31) + (*(U64*)p); p+=sizeof(U64);
-        v3 = XXH_rotl64(v3, 33) + (*(U64*)p); p+=sizeof(U64);
-        v4 = XXH_rotl64(v4, 35) + (*(U64*)p); p+=sizeof(U64);
-        v4 += v1 *= PRIME64_1;
-    }
- 
-    while (p < small_loop_limit)
-    {
-        v1 = XXH_rotl64(v1, 29) + (*(U64*)p); p+=sizeof(U64);
-        v2 += v1 *= PRIME64_1;
-        v2 = XXH_rotl64(v2, 31) + (*(U64*)p); p+=sizeof(U64);
-        v3 += v2 *= PRIME64_1;
-        v3 = XXH_rotl64(v3, 33) + (*(U64*)p); p+=sizeof(U64);
-        v4 += v3 *= PRIME64_1;
-        v4 = XXH_rotl64(v4, 35) + (*(U64*)p); p+=sizeof(U64);
-        v1 += v4 *= PRIME64_1;
-    }
-    XXH_memcpy(out, p, bEnd - p);
- 
-    out[0] += v1;
-    out[1] += v2;
-    out[2] += v3;
-    out[3] += v4;
-}
+/*======   Hash Streaming   ======*/
 
-/****************************************************
- *  Advanced Hash Functions
-****************************************************/
-
-/*** Allocation ***/
-typedef struct
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void)
 {
-    U64 total_len;
-    U32 seed;
-    U32 v1;
-    U32 v2;
-    U32 v3;
-    U32 v4;
-    U32 mem32[4];   /* defined as U32 for alignment */
-    U32 memsize;
-} XXH_istate32_t;
-
-typedef struct
-{
-    U64 total_len;
-    U64 seed;
-    U64 v1;
-    U64 v2;
-    U64 v3;
-    U64 v4;
-    U64 mem64[4];   /* defined as U64 for alignment */
-    U32 memsize;
-} XXH_istate64_t;
-
-
-XXH32_state_t* XXH32_createState(void)
-{
-    XXH_STATIC_ASSERT(sizeof(XXH32_state_t) >= sizeof(XXH_istate32_t));   // A compilation error here means XXH32_state_t is not large enough
-    return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
-}
-XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
-{
-    XXH_free(statePtr);
-    return XXH_OK;
-};
-
-XXH64_state_t* XXH64_createState(void)
-{
-    XXH_STATIC_ASSERT(sizeof(XXH64_state_t) >= sizeof(XXH_istate64_t));   // A compilation error here means XXH64_state_t is not large enough
     return (XXH64_state_t*)XXH_malloc(sizeof(XXH64_state_t));
 }
-XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
+XXH_PUBLIC_API XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
 {
     XXH_free(statePtr);
     return XXH_OK;
-};
+}
 
-
-/*** Hash feed ***/
-
-XXH_errorcode XXH32_reset(XXH32_state_t* state_in, U32 seed)
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dstState, const XXH64_state_t* srcState)
 {
-    XXH_istate32_t* state = (XXH_istate32_t*) state_in;
-    state->seed = seed;
-    state->v1 = seed + PRIME32_1 + PRIME32_2;
-    state->v2 = seed + PRIME32_2;
-    state->v3 = seed + 0;
-    state->v4 = seed - PRIME32_1;
-    state->total_len = 0;
-    state->memsize = 0;
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long long seed)
+{
+    XXH64_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
+    memset(&state, 0, sizeof(state));
+    state.v1 = seed + PRIME64_1 + PRIME64_2;
+    state.v2 = seed + PRIME64_2;
+    state.v3 = seed + 0;
+    state.v4 = seed - PRIME64_1;
+     /* do not write into reserved, planned to be removed in a future version */
+    memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved));
     return XXH_OK;
 }
 
-XXH_errorcode XXH64_reset(XXH64_state_t* state_in, unsigned long long seed)
+XXH_FORCE_INLINE XXH_errorcode
+XXH64_update_endian (XXH64_state_t* state, const void* input, size_t len, XXH_endianess endian)
 {
-    XXH_istate64_t* state = (XXH_istate64_t*) state_in;
-    state->seed = seed;
-    state->v1 = seed + PRIME64_1 + PRIME64_2;
-    state->v2 = seed + PRIME64_2;
-    state->v3 = seed + 0;
-    state->v4 = seed - PRIME64_1;
-    state->total_len = 0;
-    state->memsize = 0;
-    return XXH_OK;
-}
-
-
-FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state_in, const void* input, size_t len, XXH_endianess endian)
-{
-    XXH_istate32_t* state = (XXH_istate32_t *) state_in;
-    const BYTE* p = (const BYTE*)input;
-    const BYTE* const bEnd = p + len;
-
-#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
-    if (input==NULL) return XXH_ERROR;
+    if (input==NULL)
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+        return XXH_OK;
+#else
+        return XXH_ERROR;
 #endif
 
-    state->total_len += len;
+    {   const BYTE* p = (const BYTE*)input;
+        const BYTE* const bEnd = p + len;
 
-    if (state->memsize + len < 16)   // fill in tmp buffer
-    {
-        XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);
-        state->memsize += (U32)len;
-        return XXH_OK;
-    }
+        state->total_len += len;
 
-    if (state->memsize)   // some data left from previous update
-    {
-        XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, 16-state->memsize);
-        {
-            const U32* p32 = state->mem32;
-            state->v1 += XXH_readLE32(p32, endian) * PRIME32_2;
-            state->v1 = XXH_rotl32(state->v1, 13);
-            state->v1 *= PRIME32_1;
-            p32++;
-            state->v2 += XXH_readLE32(p32, endian) * PRIME32_2;
-            state->v2 = XXH_rotl32(state->v2, 13);
-            state->v2 *= PRIME32_1;
-            p32++;
-            state->v3 += XXH_readLE32(p32, endian) * PRIME32_2;
-            state->v3 = XXH_rotl32(state->v3, 13);
-            state->v3 *= PRIME32_1;
-            p32++;
-            state->v4 += XXH_readLE32(p32, endian) * PRIME32_2;
-            state->v4 = XXH_rotl32(state->v4, 13);
-            state->v4 *= PRIME32_1;
-            p32++;
+        if (state->memsize + len < 32) {  /* fill in tmp buffer */
+            XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, len);
+            state->memsize += (U32)len;
+            return XXH_OK;
         }
-        p += 16-state->memsize;
-        state->memsize = 0;
-    }
 
-    if (p <= bEnd-16)
-    {
-        const BYTE* const limit = bEnd - 16;
-        U32 v1 = state->v1;
-        U32 v2 = state->v2;
-        U32 v3 = state->v3;
-        U32 v4 = state->v4;
-
-        do
-        {
-            v1 += XXH_readLE32(p, endian) * PRIME32_2;
-            v1 = XXH_rotl32(v1, 13);
-            v1 *= PRIME32_1;
-            p+=4;
-            v2 += XXH_readLE32(p, endian) * PRIME32_2;
-            v2 = XXH_rotl32(v2, 13);
-            v2 *= PRIME32_1;
-            p+=4;
-            v3 += XXH_readLE32(p, endian) * PRIME32_2;
-            v3 = XXH_rotl32(v3, 13);
-            v3 *= PRIME32_1;
-            p+=4;
-            v4 += XXH_readLE32(p, endian) * PRIME32_2;
-            v4 = XXH_rotl32(v4, 13);
-            v4 *= PRIME32_1;
-            p+=4;
+        if (state->memsize) {   /* tmp buffer is full */
+            XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, 32-state->memsize);
+            state->v1 = XXH64_round(state->v1, XXH_readLE64(state->mem64+0, endian));
+            state->v2 = XXH64_round(state->v2, XXH_readLE64(state->mem64+1, endian));
+            state->v3 = XXH64_round(state->v3, XXH_readLE64(state->mem64+2, endian));
+            state->v4 = XXH64_round(state->v4, XXH_readLE64(state->mem64+3, endian));
+            p += 32-state->memsize;
+            state->memsize = 0;
         }
-        while (p<=limit);
 
-        state->v1 = v1;
-        state->v2 = v2;
-        state->v3 = v3;
-        state->v4 = v4;
-    }
+        if (p+32 <= bEnd) {
+            const BYTE* const limit = bEnd - 32;
+            U64 v1 = state->v1;
+            U64 v2 = state->v2;
+            U64 v3 = state->v3;
+            U64 v4 = state->v4;
 
-    if (p < bEnd)
-    {
-        XXH_memcpy(state->mem32, p, bEnd-p);
-        state->memsize = (int)(bEnd-p);
+            do {
+                v1 = XXH64_round(v1, XXH_readLE64(p, endian)); p+=8;
+                v2 = XXH64_round(v2, XXH_readLE64(p, endian)); p+=8;
+                v3 = XXH64_round(v3, XXH_readLE64(p, endian)); p+=8;
+                v4 = XXH64_round(v4, XXH_readLE64(p, endian)); p+=8;
+            } while (p<=limit);
+
+            state->v1 = v1;
+            state->v2 = v2;
+            state->v3 = v3;
+            state->v4 = v4;
+        }
+
+        if (p < bEnd) {
+            XXH_memcpy(state->mem64, p, (size_t)(bEnd-p));
+            state->memsize = (unsigned)(bEnd-p);
+        }
     }
 
     return XXH_OK;
 }
 
-XXH_errorcode XXH32_update (XXH32_state_t* state_in, const void* input, size_t len)
-{
-    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
-
-    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
-        return XXH32_update_endian(state_in, input, len, XXH_littleEndian);
-    else
-        return XXH32_update_endian(state_in, input, len, XXH_bigEndian);
-}
-
-
-
-FORCE_INLINE U32 XXH32_digest_endian (const XXH32_state_t* state_in, XXH_endianess endian)
-{
-    XXH_istate32_t* state = (XXH_istate32_t*) state_in;
-    const BYTE * p = (const BYTE*)state->mem32;
-    BYTE* bEnd = (BYTE*)(state->mem32) + state->memsize;
-    U32 h32;
-
-    if (state->total_len >= 16)
-    {
-        h32 = XXH_rotl32(state->v1, 1) + XXH_rotl32(state->v2, 7) + XXH_rotl32(state->v3, 12) + XXH_rotl32(state->v4, 18);
-    }
-    else
-    {
-        h32  = state->seed + PRIME32_5;
-    }
-
-    h32 += (U32) state->total_len;
-
-    while (p+4<=bEnd)
-    {
-        h32 += XXH_readLE32(p, endian) * PRIME32_3;
-        h32  = XXH_rotl32(h32, 17) * PRIME32_4;
-        p+=4;
-    }
-
-    while (p<bEnd)
-    {
-        h32 += (*p) * PRIME32_5;
-        h32 = XXH_rotl32(h32, 11) * PRIME32_1;
-        p++;
-    }
-
-    h32 ^= h32 >> 15;
-    h32 *= PRIME32_2;
-    h32 ^= h32 >> 13;
-    h32 *= PRIME32_3;
-    h32 ^= h32 >> 16;
-
-    return h32;
-}
-
-
-U32 XXH32_digest (const XXH32_state_t* state_in)
-{
-    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
-
-    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
-        return XXH32_digest_endian(state_in, XXH_littleEndian);
-    else
-        return XXH32_digest_endian(state_in, XXH_bigEndian);
-}
-
-
-FORCE_INLINE XXH_errorcode XXH64_update_endian (XXH64_state_t* state_in, const void* input, size_t len, XXH_endianess endian)
-{
-    XXH_istate64_t * state = (XXH_istate64_t *) state_in;
-    const BYTE* p = (const BYTE*)input;
-    const BYTE* const bEnd = p + len;
-
-#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
-    if (input==NULL) return XXH_ERROR;
-#endif
-
-    state->total_len += len;
-
-    if (state->memsize + len < 32)   // fill in tmp buffer
-    {
-        XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, len);
-        state->memsize += (U32)len;
-        return XXH_OK;
-    }
-
-    if (state->memsize)   // some data left from previous update
-    {
-        XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, 32-state->memsize);
-        {
-            const U64* p64 = state->mem64;
-            state->v1 += XXH_readLE64(p64, endian) * PRIME64_2;
-            state->v1 = XXH_rotl64(state->v1, 31);
-            state->v1 *= PRIME64_1;
-            p64++;
-            state->v2 += XXH_readLE64(p64, endian) * PRIME64_2;
-            state->v2 = XXH_rotl64(state->v2, 31);
-            state->v2 *= PRIME64_1;
-            p64++;
-            state->v3 += XXH_readLE64(p64, endian) * PRIME64_2;
-            state->v3 = XXH_rotl64(state->v3, 31);
-            state->v3 *= PRIME64_1;
-            p64++;
-            state->v4 += XXH_readLE64(p64, endian) * PRIME64_2;
-            state->v4 = XXH_rotl64(state->v4, 31);
-            state->v4 *= PRIME64_1;
-            p64++;
-        }
-        p += 32-state->memsize;
-        state->memsize = 0;
-    }
-
-    if (p+32 <= bEnd)
-    {
-        const BYTE* const limit = bEnd - 32;
-        U64 v1 = state->v1;
-        U64 v2 = state->v2;
-        U64 v3 = state->v3;
-        U64 v4 = state->v4;
-
-        do
-        {
-            v1 += XXH_readLE64(p, endian) * PRIME64_2;
-            v1 = XXH_rotl64(v1, 31);
-            v1 *= PRIME64_1;
-            p+=8;
-            v2 += XXH_readLE64(p, endian) * PRIME64_2;
-            v2 = XXH_rotl64(v2, 31);
-            v2 *= PRIME64_1;
-            p+=8;
-            v3 += XXH_readLE64(p, endian) * PRIME64_2;
-            v3 = XXH_rotl64(v3, 31);
-            v3 *= PRIME64_1;
-            p+=8;
-            v4 += XXH_readLE64(p, endian) * PRIME64_2;
-            v4 = XXH_rotl64(v4, 31);
-            v4 *= PRIME64_1;
-            p+=8;
-        }
-        while (p<=limit);
-
-        state->v1 = v1;
-        state->v2 = v2;
-        state->v3 = v3;
-        state->v4 = v4;
-    }
-
-    if (p < bEnd)
-    {
-        XXH_memcpy(state->mem64, p, bEnd-p);
-        state->memsize = (int)(bEnd-p);
-    }
-
-    return XXH_OK;
-}
-
-XXH_errorcode XXH64_update (XXH64_state_t* state_in, const void* input, size_t len)
+XXH_PUBLIC_API XXH_errorcode XXH64_update (XXH64_state_t* state_in, const void* input, size_t len)
 {
     XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
 
@@ -900,91 +980,31 @@ XXH_errorcode XXH64_update (XXH64_state_t* state_in, const void* input, size_t l
         return XXH64_update_endian(state_in, input, len, XXH_bigEndian);
 }
 
-
-
-FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state_in, XXH_endianess endian)
+XXH_FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state, XXH_endianess endian)
 {
-    XXH_istate64_t * state = (XXH_istate64_t *) state_in;
-    const BYTE * p = (const BYTE*)state->mem64;
-    BYTE* bEnd = (BYTE*)state->mem64 + state->memsize;
     U64 h64;
 
-    if (state->total_len >= 32)
-    {
-        U64 v1 = state->v1;
-        U64 v2 = state->v2;
-        U64 v3 = state->v3;
-        U64 v4 = state->v4;
+    if (state->total_len >= 32) {
+        U64 const v1 = state->v1;
+        U64 const v2 = state->v2;
+        U64 const v3 = state->v3;
+        U64 const v4 = state->v4;
 
         h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
-
-        v1 *= PRIME64_2;
-        v1 = XXH_rotl64(v1, 31);
-        v1 *= PRIME64_1;
-        h64 ^= v1;
-        h64 = h64*PRIME64_1 + PRIME64_4;
-
-        v2 *= PRIME64_2;
-        v2 = XXH_rotl64(v2, 31);
-        v2 *= PRIME64_1;
-        h64 ^= v2;
-        h64 = h64*PRIME64_1 + PRIME64_4;
-
-        v3 *= PRIME64_2;
-        v3 = XXH_rotl64(v3, 31);
-        v3 *= PRIME64_1;
-        h64 ^= v3;
-        h64 = h64*PRIME64_1 + PRIME64_4;
-
-        v4 *= PRIME64_2;
-        v4 = XXH_rotl64(v4, 31);
-        v4 *= PRIME64_1;
-        h64 ^= v4;
-        h64 = h64*PRIME64_1 + PRIME64_4;
-    }
-    else
-    {
-        h64  = state->seed + PRIME64_5;
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
+    } else {
+        h64  = state->v3 /*seed*/ + PRIME64_5;
     }
 
     h64 += (U64) state->total_len;
 
-    while (p+8<=bEnd)
-    {
-        U64 k1 = XXH_readLE64(p, endian);
-        k1 *= PRIME64_2;
-        k1 = XXH_rotl64(k1,31);
-        k1 *= PRIME64_1;
-        h64 ^= k1;
-        h64 = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4;
-        p+=8;
-    }
-
-    if (p+4<=bEnd)
-    {
-        h64 ^= (U64)(XXH_readLE32(p, endian)) * PRIME64_1;
-        h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
-        p+=4;
-    }
-
-    while (p<bEnd)
-    {
-        h64 ^= (*p) * PRIME64_5;
-        h64 = XXH_rotl64(h64, 11) * PRIME64_1;
-        p++;
-    }
-
-    h64 ^= h64 >> 33;
-    h64 *= PRIME64_2;
-    h64 ^= h64 >> 29;
-    h64 *= PRIME64_3;
-    h64 ^= h64 >> 32;
-
-    return h64;
+    return XXH64_finalize(h64, state->mem64, (size_t)state->total_len, endian, XXH_aligned);
 }
 
-
-unsigned long long XXH64_digest (const XXH64_state_t* state_in)
+XXH_PUBLIC_API unsigned long long XXH64_digest (const XXH64_state_t* state_in)
 {
     XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
 
@@ -993,3 +1013,20 @@ unsigned long long XXH64_digest (const XXH64_state_t* state_in)
     else
         return XXH64_digest_endian(state_in, XXH_bigEndian);
 }
+
+
+/*====== Canonical representation   ======*/
+
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH64_canonical_t) == sizeof(XXH64_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap64(hash);
+    memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src)
+{
+    return XXH_readBE64(src);
+}
+
+#endif  /* XXH_NO_LONG_LONG */

--- a/xxhash.h
+++ b/xxhash.h
@@ -1,7 +1,8 @@
 /*
    xxHash - Extremely Fast Hash algorithm
    Header File
-   Copyright (C) 2012-2014, Yann Collet.
+   Copyright (C) 2012-2016, Yann Collet.
+
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
    Redistribution and use in source and binary forms, with or without
@@ -28,7 +29,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    You can contact the author at :
-   - xxHash source repository : http://code.google.com/p/xxhash/
+   - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 
 /* Notice extracted from xxHash homepage :
@@ -55,102 +56,273 @@ SHA1-32         0.28 GB/s    10
 Q.Score is a measure of quality of the hash function.
 It depends on successfully passing SMHasher test set.
 10 is a perfect score.
+
+A 64-bit version, named XXH64, is available since r35.
+It offers much better speed, but for 64-bit applications only.
+Name     Speed on 64 bits    Speed on 32 bits
+XXH64       13.8 GB/s            1.9 GB/s
+XXH32        6.8 GB/s            6.0 GB/s
 */
 
-#pragma once
+#ifndef XXHASH_H_5627135585666179
+#define XXHASH_H_5627135585666179 1
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
 
-/*****************************
-   Includes
-*****************************/
+/* ****************************
+*  Definitions
+******************************/
 #include <stddef.h>   /* size_t */
-
-
-/*****************************
-   Type
-*****************************/
 typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 
 
+/* ****************************
+ *  API modifier
+ ******************************/
+/** XXH_INLINE_ALL (and XXH_PRIVATE_API)
+ *  This is useful to include xxhash functions in `static` mode
+ *  in order to inline them, and remove their symbol from the public list.
+ *  Inlining can offer dramatic performance improvement on small keys.
+ *  Methodology :
+ *     #define XXH_INLINE_ALL
+ *     #include "xxhash.h"
+ * `xxhash.c` is automatically included.
+ *  It's not useful to compile and link it as a separate module.
+ */
+#if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
+#  ifndef XXH_STATIC_LINKING_ONLY
+#    define XXH_STATIC_LINKING_ONLY
+#  endif
+#  if defined(__GNUC__)
+#    define XXH_PUBLIC_API static __inline __attribute__((unused))
+#  elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#    define XXH_PUBLIC_API static inline
+#  elif defined(_MSC_VER)
+#    define XXH_PUBLIC_API static __inline
+#  else
+     /* this version may generate warnings for unused static functions */
+#    define XXH_PUBLIC_API static
+#  endif
+#else
+#  define XXH_PUBLIC_API   /* do nothing */
+#endif /* XXH_INLINE_ALL || XXH_PRIVATE_API */
 
-/*****************************
-   Simple Hash Functions
-*****************************/
+/*! XXH_NAMESPACE, aka Namespace Emulation :
+ *
+ * If you want to include _and expose_ xxHash functions from within your own library,
+ * but also want to avoid symbol collisions with other libraries which may also include xxHash,
+ *
+ * you can use XXH_NAMESPACE, to automatically prefix any public symbol from xxhash library
+ * with the value of XXH_NAMESPACE (therefore, avoid NULL and numeric values).
+ *
+ * Note that no change is required within the calling program as long as it includes `xxhash.h` :
+ * regular symbol name will be automatically translated by this header.
+ */
+#ifdef XXH_NAMESPACE
+#  define XXH_CAT(A,B) A##B
+#  define XXH_NAME2(A,B) XXH_CAT(A,B)
+#  define XXH_versionNumber XXH_NAME2(XXH_NAMESPACE, XXH_versionNumber)
+#  define XXH32 XXH_NAME2(XXH_NAMESPACE, XXH32)
+#  define XXH32_createState XXH_NAME2(XXH_NAMESPACE, XXH32_createState)
+#  define XXH32_freeState XXH_NAME2(XXH_NAMESPACE, XXH32_freeState)
+#  define XXH32_reset XXH_NAME2(XXH_NAMESPACE, XXH32_reset)
+#  define XXH32_update XXH_NAME2(XXH_NAMESPACE, XXH32_update)
+#  define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
+#  define XXH32_copyState XXH_NAME2(XXH_NAMESPACE, XXH32_copyState)
+#  define XXH32_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH32_canonicalFromHash)
+#  define XXH32_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH32_hashFromCanonical)
+#  define XXH64 XXH_NAME2(XXH_NAMESPACE, XXH64)
+#  define XXH64_createState XXH_NAME2(XXH_NAMESPACE, XXH64_createState)
+#  define XXH64_freeState XXH_NAME2(XXH_NAMESPACE, XXH64_freeState)
+#  define XXH64_reset XXH_NAME2(XXH_NAMESPACE, XXH64_reset)
+#  define XXH64_update XXH_NAME2(XXH_NAMESPACE, XXH64_update)
+#  define XXH64_digest XXH_NAME2(XXH_NAMESPACE, XXH64_digest)
+#  define XXH64_copyState XXH_NAME2(XXH_NAMESPACE, XXH64_copyState)
+#  define XXH64_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH64_canonicalFromHash)
+#  define XXH64_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH64_hashFromCanonical)
+#endif
 
-unsigned int       XXH32 (const void* input, size_t length, unsigned seed);
-unsigned long long XXH64 (const void* input, size_t length, unsigned long long seed);
 
-/*
-XXH32() :
-    Calculate the 32-bits hash of sequence "length" bytes stored at memory address "input".
+/* *************************************
+*  Version
+***************************************/
+#define XXH_VERSION_MAJOR    0
+#define XXH_VERSION_MINOR    6
+#define XXH_VERSION_RELEASE  5
+#define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
+XXH_PUBLIC_API unsigned XXH_versionNumber (void);
+
+
+/*-**********************************************************************
+*  32-bit hash
+************************************************************************/
+typedef unsigned int XXH32_hash_t;
+
+/*! XXH32() :
+    Calculate the 32-bit hash of sequence "length" bytes stored at memory address "input".
     The memory between input & input+length must be valid (allocated and read-accessible).
     "seed" can be used to alter the result predictably.
-    This function successfully passes all SMHasher tests.
-    Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark) : 5.4 GB/s
-XXH64() :
-    Calculate the 64-bits hash of sequence of length "len" stored at memory address "input".
-*/
+    Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark) : 5.4 GB/s */
+XXH_PUBLIC_API XXH32_hash_t XXH32 (const void* input, size_t length, unsigned int seed);
 
+/*======   Streaming   ======*/
+typedef struct XXH32_state_s XXH32_state_t;   /* incomplete type */
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void);
+XXH_PUBLIC_API XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dst_state, const XXH32_state_t* src_state);
 
-
-/*****************************
-   Advanced Hash Functions
-*****************************/
-typedef struct { long long ll[ 6]; } XXH32_state_t;
-typedef struct { long long ll[11]; } XXH64_state_t;
-
-/*
-These structures allow static allocation of XXH states.
-States must then be initialized using XXHnn_reset() before first use.
-
-If you prefer dynamic allocation, please refer to functions below.
-*/
-
-XXH32_state_t* XXH32_createState(void);
-XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
-
-XXH64_state_t* XXH64_createState(void);
-XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
+XXH_PUBLIC_API XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, unsigned int seed);
+XXH_PUBLIC_API XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH32_hash_t  XXH32_digest (const XXH32_state_t* statePtr);
 
 /*
-These functions create and release memory for XXH state.
-States must then be initialized using XXHnn_reset() before first use.
+ * Streaming functions generate the xxHash of an input provided in multiple segments.
+ * Note that, for small input, they are slower than single-call functions, due to state management.
+ * For small inputs, prefer `XXH32()` and `XXH64()`, which are better optimized.
+ *
+ * XXH state must first be allocated, using XXH*_createState() .
+ *
+ * Start a new hash by initializing state with a seed, using XXH*_reset().
+ *
+ * Then, feed the hash state by calling XXH*_update() as many times as necessary.
+ * The function returns an error code, with 0 meaning OK, and any other value meaning there is an error.
+ *
+ * Finally, a hash value can be produced anytime, by using XXH*_digest().
+ * This function returns the nn-bits hash as an int or long long.
+ *
+ * It's still possible to continue inserting input into the hash state after a digest,
+ * and generate some new hashes later on, by calling again XXH*_digest().
+ *
+ * When done, free XXH state space if it was allocated dynamically.
+ */
+
+/*======   Canonical representation   ======*/
+
+typedef struct { unsigned char digest[4]; } XXH32_canonical_t;
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash);
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src);
+
+/* Default result type for XXH functions are primitive unsigned 32 and 64 bits.
+ * The canonical representation uses human-readable write convention, aka big-endian (large digits first).
+ * These functions allow transformation of hash result into and from its canonical format.
+ * This way, hash values can be written into a file / memory, and remain comparable on different systems and programs.
+ */
+
+
+#ifndef XXH_NO_LONG_LONG
+/*-**********************************************************************
+*  64-bit hash
+************************************************************************/
+typedef unsigned long long XXH64_hash_t;
+
+/*! XXH64() :
+    Calculate the 64-bit hash of sequence of length "len" stored at memory address "input".
+    "seed" can be used to alter the result predictably.
+    This function runs faster on 64-bit systems, but slower on 32-bit systems (see benchmark).
 */
+XXH_PUBLIC_API XXH64_hash_t XXH64 (const void* input, size_t length, unsigned long long seed);
+
+/*======   Streaming   ======*/
+typedef struct XXH64_state_s XXH64_state_t;   /* incomplete type */
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void);
+XXH_PUBLIC_API XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dst_state, const XXH64_state_t* src_state);
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset  (XXH64_state_t* statePtr, unsigned long long seed);
+XXH_PUBLIC_API XXH_errorcode XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH64_hash_t  XXH64_digest (const XXH64_state_t* statePtr);
+
+/*======   Canonical representation   ======*/
+typedef struct { unsigned char digest[8]; } XXH64_canonical_t;
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash);
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src);
+#endif  /* XXH_NO_LONG_LONG */
 
 
-XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, unsigned seed);
-XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
-unsigned int  XXH32_digest (const XXH32_state_t* statePtr);
 
-XXH_errorcode      XXH64_reset  (XXH64_state_t* statePtr, unsigned long long seed);
-XXH_errorcode      XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length);
-unsigned long long XXH64_digest (const XXH64_state_t* statePtr);
+#ifdef XXH_STATIC_LINKING_ONLY
 
-/*
-These functions calculate the xxHash of an input provided in multiple smaller packets,
-as opposed to an input provided as a single block.
+/* ================================================================================================
+   This section contains declarations which are not guaranteed to remain stable.
+   They may change in future versions, becoming incompatible with a different version of the library.
+   These declarations should only be used with static linking.
+   Never use them in association with dynamic linking !
+=================================================================================================== */
 
-XXH state space must first be allocated, using either static or dynamic method provided above.
+/* These definitions are only present to allow
+ * static allocation of XXH state, on stack or in a struct for example.
+ * Never **ever** use members directly. */
 
-Start a new hash by initializing state with a seed, using XXHnn_reset().
+#if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
 
-Then, feed the hash state by calling XXHnn_update() as many times as necessary.
-Obviously, input must be valid, meaning allocated and read accessible.
-The function returns an error code, with 0 meaning OK, and any other value meaning there is an error.
+struct XXH32_state_s {
+   uint32_t total_len_32;
+   uint32_t large_len;
+   uint32_t v1;
+   uint32_t v2;
+   uint32_t v3;
+   uint32_t v4;
+   uint32_t mem32[4];
+   uint32_t memsize;
+   uint32_t reserved;   /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH32_state_t */
 
-Finally, you can produce a hash anytime, by using XXHnn_digest().
-This function returns the final nn-bits hash.
-You can nonetheless continue feeding the hash state with more input,
-and therefore get some new hashes, by calling again XXHnn_digest().
+struct XXH64_state_s {
+   uint64_t total_len;
+   uint64_t v1;
+   uint64_t v2;
+   uint64_t v3;
+   uint64_t v4;
+   uint64_t mem64[4];
+   uint32_t memsize;
+   uint32_t reserved[2];          /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH64_state_t */
 
-When you are done, don't forget to free XXH state space, using typically XXHnn_freeState().
-*/
+# else
+
+struct XXH32_state_s {
+   unsigned total_len_32;
+   unsigned large_len;
+   unsigned v1;
+   unsigned v2;
+   unsigned v3;
+   unsigned v4;
+   unsigned mem32[4];
+   unsigned memsize;
+   unsigned reserved;   /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH32_state_t */
+
+#   ifndef XXH_NO_LONG_LONG  /* remove 64-bit support */
+struct XXH64_state_s {
+   unsigned long long total_len;
+   unsigned long long v1;
+   unsigned long long v2;
+   unsigned long long v3;
+   unsigned long long v4;
+   unsigned long long mem64[4];
+   unsigned memsize;
+   unsigned reserved[2];     /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH64_state_t */
+#    endif
+
+# endif
+
+
+#if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
+#  include "xxhash.c"   /* include xxhash function bodies as `static`, for inlining */
+#endif
+
+#endif /* XXH_STATIC_LINKING_ONLY */
 
 
 #if defined (__cplusplus)
 }
 #endif
+
+#endif /* XXHASH_H_5627135585666179 */

--- a/xxhash.h
+++ b/xxhash.h
@@ -107,7 +107,15 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 #    define XXH_PUBLIC_API static
 #  endif
 #else
-#  define XXH_PUBLIC_API   /* do nothing */
+#  if defined(WIN32) && !defined(__GNUC__)
+#    ifdef XXH_EXPORT
+#      define XXH_PUBLIC_API __declspec(dllexport)
+#    else
+#      define XXH_PUBLIC_API __declspec(dllimport)
+#    endif
+#  else
+#    define XXH_PUBLIC_API   /* do nothing */
+#  endif
 #endif /* XXH_INLINE_ALL || XXH_PRIVATE_API */
 
 /*! XXH_NAMESPACE, aka Namespace Emulation :
@@ -150,8 +158,8 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 *  Version
 ***************************************/
 #define XXH_VERSION_MAJOR    0
-#define XXH_VERSION_MINOR    6
-#define XXH_VERSION_RELEASE  5
+#define XXH_VERSION_MINOR    7
+#define XXH_VERSION_RELEASE  0
 #define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
 XXH_PUBLIC_API unsigned XXH_versionNumber (void);
 
@@ -239,6 +247,8 @@ XXH_PUBLIC_API XXH64_hash_t  XXH64_digest (const XXH64_state_t* statePtr);
 typedef struct { unsigned char digest[8]; } XXH64_canonical_t;
 XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash);
 XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src);
+
+
 #endif  /* XXH_NO_LONG_LONG */
 
 
@@ -281,42 +291,149 @@ struct XXH64_state_s {
    uint64_t v4;
    uint64_t mem64[4];
    uint32_t memsize;
-   uint32_t reserved[2];          /* never read nor write, might be removed in a future version */
+   uint32_t reserved[2];   /* never read nor write, might be removed in a future version */
 };   /* typedef'd to XXH64_state_t */
 
 # else
 
 struct XXH32_state_s {
-   unsigned total_len_32;
-   unsigned large_len;
-   unsigned v1;
-   unsigned v2;
-   unsigned v3;
-   unsigned v4;
-   unsigned mem32[4];
-   unsigned memsize;
-   unsigned reserved;   /* never read nor write, might be removed in a future version */
+   XXH32_hash_t total_len_32;
+   XXH32_hash_t large_len;
+   XXH32_hash_t v1;
+   XXH32_hash_t v2;
+   XXH32_hash_t v3;
+   XXH32_hash_t v4;
+   XXH32_hash_t mem32[4];
+   XXH32_hash_t memsize;
+   XXH32_hash_t reserved;   /* never read nor write, might be removed in a future version */
 };   /* typedef'd to XXH32_state_t */
 
 #   ifndef XXH_NO_LONG_LONG  /* remove 64-bit support */
 struct XXH64_state_s {
-   unsigned long long total_len;
-   unsigned long long v1;
-   unsigned long long v2;
-   unsigned long long v3;
-   unsigned long long v4;
-   unsigned long long mem64[4];
-   unsigned memsize;
-   unsigned reserved[2];     /* never read nor write, might be removed in a future version */
+   XXH64_hash_t total_len;
+   XXH64_hash_t v1;
+   XXH64_hash_t v2;
+   XXH64_hash_t v3;
+   XXH64_hash_t v4;
+   XXH64_hash_t mem64[4];
+   XXH32_hash_t memsize;
+   XXH32_hash_t reserved[2];     /* never read nor write, might be removed in a future version */
 };   /* typedef'd to XXH64_state_t */
 #    endif
 
 # endif
 
 
+/*-**********************************************************************
+*  XXH3
+*  New experimental hash
+************************************************************************/
+#ifndef XXH_NO_LONG_LONG
+
+
+/* ============================================
+ * XXH3 is a new hash algorithm,
+ * featuring vastly improved speed performance
+ * for both small and large inputs.
+ * A full speed analysis will be published,
+ * it requires a lot more space than this comment can handle.
+ * In general, expect XXH3 to run about ~2x faster on large inputs,
+ * and >3x faster on small ones, though exact difference depend on platform.
+ *
+ * The algorithm is portable, will generate the same hash on all platforms.
+ * It benefits greatly from vectorization units, but does not require it.
+ *
+ * XXH3 offers 2 variants, _64bits and _128bits.
+ * When only 64 bits are needed, prefer calling the _64bits variant :
+ * it reduces the amount of mixing, resulting in faster speed on small inputs.
+ * It's also generally simpler to manipulate a scalar type than a struct.
+ * Note : the low 64-bit field of the _128bits variant is the same as _64bits result.
+ *
+ * The XXH3 algorithm is still considered experimental.
+ * It's possible to use it for ephemeral data, but avoid storing long-term values for later re-use.
+ * While labelled experimental, the produced result can still change between versions.
+ *
+ * The API currently supports one-shot hashing only.
+ * The full version will include streaming capability, and canonical representation
+ * Long term optional feature may include custom secret keys, and secret key generation.
+ *
+ * There are still a number of opened questions that community can influence during the experimental period.
+ * I'm trying to list a few of them below, though don't consider this list as complete.
+ *
+ * - 128-bits output type : currently defined as a structure of 2 64-bits fields.
+ *                          That's because 128-bit values do not exist in C standard.
+ *                          Note that it means that, at byte level, result is not identical depending on endianess.
+ *                          However, at field level, they are identical on all platforms.
+ *                          The canonical representation will solve the issue of identical byte-level representation across platforms,
+ *                          which is necessary for serialization.
+ *                          Would there be a better representation for a 128-bit hash result ?
+ *                          Are the names of the inner 64-bit fields important ? Should they be changed ?
+ *
+ * - Canonical representation : for the 64-bit variant, canonical representation is the same as XXH64() (aka big-endian).
+ *                          What should it be for the 128-bit variant ?
+ *                          Since it's no longer a scalar value, big-endian representation is no longer an obvious choice.
+ *                          One possibility : represent it as the concatenation of two 64-bits canonical representation (aka 2x big-endian)
+ *                          Another one : represent it in the same order as natural order in the struct for little-endian platforms.
+ *                                        Less consistent with existing convention for XXH32/XXH64, but may be more natural for little-endian platforms.
+ *
+ * - Associated functions for 128-bit hash : simple things, such as checking if 2 hashes are equal, become more difficult with struct.
+ *                          Granted, it's not terribly difficult to create a comparator, but it's still a workload.
+ *                          Would it be beneficial to declare and define a comparator function for XXH128_hash_t ?
+ *                          Are there other operations on XXH128_hash_t which would be desirable ?
+ *
+ * - Variant compatibility : The low 64-bit field of the _128bits variant is the same as the result of _64bits.
+ *                          This is not a compulsory behavior. It just felt that it "wouldn't hurt", and might even help in some (unidentified) cases.
+ *                          But it might influence the design of XXH128_hash_t, in ways which may block other possibilities.
+ *                          Good idea, bad idea ?
+ *
+ * - Seed type for 128-bits variant : currently, it's a single 64-bit value, like the 64-bit variant.
+ *                          It could be argued that it's more logical to offer a 128-bit seed input parameter for a 128-bit hash.
+ *                          Although it's also more difficult to use, since it requires to declare and pass a structure instead of a value.
+ *                          It would either replace current choice, or add a new one.
+ *                          Farmhash, for example, offers both variants (the 128-bits seed variant is called `doubleSeed`).
+ *                          If both 64-bit and 128-bit seeds are possible, which variant should be called XXH128 ?
+ *
+ * - Result for len==0 : Currently, the result of hashing a zero-length input is the seed.
+ *                          This mimics the behavior of a crc : in which case, a seed is effectively an accumulator, so it's not updated if input is empty.
+ *                          Consequently, by default, when no seed specified, it returns zero. That part seems okay (it used to be a request for XXH32/XXH64).
+ *                          But is it still fine to return the seed when the seed is non-zero ?
+ *                          Are there use case which would depend on this behavior, or would prefer a mixing of the seed ?
+ */
+
+#ifdef XXH_NAMESPACE
+#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
+#  define XXH3_64bits XXH_NAME2(XXH_NAMESPACE, XXH3_64bits)
+#  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
+#  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
+#  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
+#endif
+
+
+typedef struct {
+    XXH64_hash_t low64;
+    XXH64_hash_t high64;
+} XXH128_hash_t;
+
+XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, unsigned long long seed);
+
+/* note : variants without seed produce same result as variant with seed == 0 */
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits(const void* data, size_t len);
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, unsigned long long seed);
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len);
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, unsigned long long seed);  /* == XXH128() */
+
+
+#endif  /* XXH_NO_LONG_LONG */
+
+
+/*-**********************************************************************
+*  XXH_INLINE_ALL
+************************************************************************/
 #if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
 #  include "xxhash.c"   /* include xxhash function bodies as `static`, for inlining */
 #endif
+
+
 
 #endif /* XXH_STATIC_LINKING_ONLY */
 


### PR DESCRIPTION
Most SMHasher tests are designed around "small" input length, in order to scout a tractable search space. Unfortunately, many modern hash algorithms feature different code paths depending on the input size. As a consequence, path for large input lengths are not stressed enough, which makes it possible to "pass" the tests, while they were effectively skipped.

Another factor is that computing capacity has increased a lot since SMHasher initial release, and it's now less problematic to run and analyse many more results per test.

This patch proposes to extend test limits, at the cost of higher computation cost.
The most important modifications are : 
- Sparse tests (up to 1.2 KB input)
- Permutation (up to 3 KB input)
- Avalanche (up to 192 bytes input)
There are other minor extension in "seed" and "zeroes" tests.

This patch also : 
- Reorder tests, in order to run the most important ones first. "Sparse" tests in particular proved really powerful at finding collisions.
- Updates xxHash library
- Add `XXH3` and `XXH128` to the list of algorithms that can be tested
- Add `CityHash64noSeed` and `FarmHash64noSeed`, as they feature a different result on Avalanche / bias tests
- Adds several 32-bits extracts from larger bit sets
    + the reason is, for 64-bit and larger hashes, all collision results must be "0", which is necessary but not precise enough. Analyzing per 32-bit part, it's now possible to check if each sub-part of the hash respects the birthday paradox bound.
- Update a few results in `/doc`
