### PR TITLE
Improve collision rate evaluation for large hashes

### DIFF
--- a/Bitvec.cpp
+++ b/Bitvec.cpp
@@ -63,7 +63,7 @@ void printhex32 ( const void * blob, int len )
 
   printf("{ ");
 
-  for(int i = 0; i < len/4; i++) 
+  for(int i = 0; i < len/4; i++)
   {
     printf("0x%08x, ",d[i]);
   }
@@ -125,7 +125,7 @@ uint32_t getbit ( const void * block, int len, uint32_t bit )
 
   int byte = bit >> 3;
   bit = bit & 0x7;
-  
+
   if(byte < len) return (b[byte] >> bit) & 1;
 
   return 0;
@@ -137,9 +137,9 @@ uint32_t getbit_wrap ( const void * block, int len, uint32_t bit )
 
   int byte = bit >> 3;
   bit = bit & 0x7;
-  
+
   byte %= len;
-    
+
   return (b[byte] >> bit) & 1;
 }
 
@@ -149,7 +149,7 @@ void setbit ( void * block, int len, uint32_t bit )
 
   int byte = bit >> 3;
   bit = bit & 0x7;
-  
+
   if(byte < len) b[byte] |= (1 << bit);
 }
 
@@ -164,7 +164,7 @@ void clearbit ( void * block, int len, uint32_t bit )
 
   int byte = bit >> 3;
   bit = bit & 0x7;
-  
+
   if(byte < len) b[byte] &= ~(1 << bit);
 }
 
@@ -174,7 +174,7 @@ void flipbit ( void * block, int len, uint32_t bit )
 
   int byte = bit >> 3;
   bit = bit & 0x7;
-  
+
   if(byte < len) b[byte] ^= (1 << bit);
 }
 
@@ -283,11 +283,11 @@ void rshift1 ( void * blob, int len, int c )
 
 void rshift8 ( void * blob, int nbytes, int c )
 {
-  uint8_t * k = (uint8_t*)blob;
+  uint8_t* k = (uint8_t*)blob;
 
   if(c == 0) return;
 
-  int b = c >> 3;
+  int const b = c >> 3;
   c &= 7;
 
   for(int i = 0; i < nbytes-b; i++)
@@ -579,7 +579,7 @@ uint32_t window8 ( void * blob, int len, int start, int count )
 
     uint32_t a = k[ia];
     uint32_t b = k[ib];
-    
+
     uint32_t m = (a << (8-c)) | (b >> c);
 
     t |= (m << (8*i));
@@ -614,7 +614,7 @@ uint32_t window32 ( void * blob, int len, int start, int count )
 
   uint32_t a = k[ia];
   uint32_t b = k[ib];
-  
+
   uint32_t t = (a << (32-c)) | (b >> c);
 
   t &= ((1 << count)-1);
@@ -669,7 +669,7 @@ template < int nbits >
 bool test_window2 ( void )
 {
   Rand r(83874);
-  
+
   struct keytype
   {
     uint8_t bytes[nbits/8];
@@ -708,7 +708,7 @@ bool test_window2 ( void )
 bool test_window ( void )
 {
   Rand r(48402);
-  
+
   int reps = 10000;
 
   for(int j = 0; j < reps; j++)
@@ -726,7 +726,7 @@ bool test_window ( void )
       {
         uint32_t a = (uint32_t)ROTR64(x,start);
         a &= ((1 << count)-1);
-        
+
         uint32_t b = window1 (&x,nbytes,start,count);
         uint32_t c = window8 (&x,nbytes,start,count);
         uint32_t d = window32(&x,nbytes,start,count);

--- a/Bitvec.h
+++ b/Bitvec.h
@@ -80,11 +80,11 @@ inline void lshift ( void * blob, int len, int c )
 {
   if((len & 3) == 0)
   {
-    lshift32(blob,len,c);
+    lshift32(blob, len, c);
   }
   else
   {
-    lshift8(blob,len,c);
+    lshift8(blob, len, c);
   }
 }
 
@@ -92,11 +92,11 @@ inline void rshift ( void * blob, int len, int c )
 {
   if((len & 3) == 0)
   {
-    rshift32(blob,len,c);
+    rshift32(blob, len, c);
   }
   else
   {
-    rshift8(blob,len,c);
+    rshift8(blob, len, c);
   }
 }
 
@@ -230,13 +230,13 @@ inline uint32_t window ( T & blob, int start, int count )
   }
 }
 
-template<> 
+template<>
 inline uint32_t window ( uint32_t & blob, int start, int count )
 {
   return ROTR32(blob,start) & ((1<<count)-1);
 }
 
-template<> 
+template<>
 inline uint32_t window ( uint64_t & blob, int start, int count )
 {
   return (uint32_t)ROTR64(blob,start) & ((1<<count)-1);

--- a/Hashes.h
+++ b/Hashes.h
@@ -87,11 +87,6 @@ inline void CityHash64_low_test ( const void * key, int len, uint32_t seed, void
   CityHash64_test(key, len, seed, &result);
   *(uint32_t*)out = (uint32_t)result;
 }
-inline void CityHash64_high_test ( const void * key, int len, uint32_t seed, void * out ) {
-  uint64_t result;
-  CityHash64_test(key, len, seed, &result);
-  *(uint32_t*)out = (uint32_t)(result>>32);
-}
 void CityHash128_test      ( const void * key, int len, uint32_t seed, void * out );
 void FarmHash32_test       ( const void * key, int len, uint32_t seed, void * out );
 void FarmHash64_test       ( const void * key, int len, uint32_t seed, void * out );
@@ -172,11 +167,6 @@ inline void xxh3low_test( const void * key, int len, uint32_t seed, void * out )
   *(uint32_t*)out = (uint32_t) XXH3_64bits(key, (size_t) len);
 }
 
-inline void xxh3high_test( const void * key, int len, uint32_t seed, void * out ) {
-  (void)seed;
-  *(uint32_t*)out = (uint32_t) (XXH3_64bits(key, (size_t) len) >> 32);
-}
-
 inline void xxh128_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
   *(XXH128_hash_t*)out = XXH128(key, (size_t) len, seed);
@@ -185,11 +175,6 @@ inline void xxh128_test( const void * key, int len, uint32_t seed, void * out ) 
 inline void xxh128low_test( const void * key, int len, uint32_t seed, void * out ) {
   (void)seed;
   *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).low64);
-}
-
-inline void xxh128high_test( const void * key, int len, uint32_t seed, void * out ) {
-  (void)seed;
-  *(uint64_t*)out = (uint64_t) (XXH128(key, (size_t) len, seed).high64);
 }
 
 
@@ -242,11 +227,6 @@ inline void mum_low_test ( const void * key, int len, uint32_t seed, void * out 
   uint64_t result;
   mum_hash_test(key, len, seed, &result);
   *(uint32_t*)out = (uint32_t)result;
-}
-inline void mum_high_test ( const void * key, int len, uint32_t seed, void * out ) {
-  uint64_t result;
-  mum_hash_test(key, len, seed, &result);
-  *(uint32_t*)out = (uint32_t)(result>>32);
 }
 
 

--- a/KeysetTest.h
+++ b/KeysetTest.h
@@ -263,7 +263,8 @@ bool WindowedKeyTest ( hashfunc<hashtype> hash, const int windowbits, bool testC
 
     printf("Window at %3d - ",j);
 
-    result &= TestHashList(hashes,testCollision,testDistribution,drawDiagram);
+    result &= TestHashList(hashes, testCollision, testDistribution, drawDiagram,
+                false);   /* do not test high bits (to not clobber the screen) */
 
     //printf("\n");
   }

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ SMhasher
 | [CityCrc128](doc/CityCrc128)          |     19348.29  |    48.34 |                            |
 | [FarmHash64](doc/FarmHash64)         	|     14899.89  |    42.41 |                            |
 | [FarmHash128](doc/FarmHash128)        |     15998.86  |    58.12 |                            |
-| [FarmHash32](doc/FarmHash32)         	|     24831.45  |    24.99| machine-specific (x86_64 SSE4/AVX) |
-| [farmhash32_c](doc/farmhash32_c)      |     24647.21  |    25.36| machine-specific (x86_64 SSE4/AVX) |
+| [FarmHash32](doc/FarmHash32)         	|     24831.45  |    24.99 | machine-specific (x86_64 SSE4/AVX) |
+| [farmhash32_c](doc/farmhash32_c)      |     24647.21  |    25.36 | machine-specific (x86_64 SSE4/AVX) |
 | [farmhash64_c](doc/farmhash64_c)     	|     14967.76  |    42.01 |                            |
 | [farmhash128_c](doc/farmhash128_c)    |     15097.31  |    61.00 |                            |
 | [xxHash32](doc/xxHash32)              |      7297.39	|    36.91 | collisions with 4bit diff  |
@@ -87,10 +87,10 @@ SMhasher
 | [metrohash64crc_2](doc/metrohash64crc_2)  | 26450.83	|    39.74 | cyclic collisions 8 byte, machine-specific (x64  SSE4.2) |
 | [metrohash128crc_1](doc/metrohash128crc_1)| 25404.51	|    49.07 | machine-specific (x64 SSE4.2) |
 | [metrohash128crc_2](doc/metrohash128crc_2)| 25248.70	|    49.57 | machine-specific (x64 SSE4.2) |
-| [cmetrohash64_1o](doc/cmetrohash64_1o)    |  15997.88	|    37.07 |                            |
-| [cmetrohash64_1](doc/cmetrohash64_1)      |  17094.64	|    36.85 |                            |
-| [cmetrohash64_2](doc/cmetrohash64_2)      |  15952.55	|    38.87 |                            |
-| [falkhash](doc/falkhash)              |     37742.94	|   108.59 | machine-specific (x86_64 AES-NI) |
+| [cmetrohash64_1o](doc/cmetrohash64_1o)    | 15997.88	|    37.07 | LongNeighbors              |
+| [cmetrohash64_1](doc/cmetrohash64_1)      | 17094.64	|    36.85 |                            |
+| [cmetrohash64_2](doc/cmetrohash64_2)      | 15952.55	|    38.87 |                            |
+| [falkhash](doc/falkhash)              |     37742.94	|   108.59 | LongNeighbors, machine-specific (x86_64 AES-NI) |
 | [t1ha2_atonce](doc/t1ha2_atonce)      |     14747.01	|    36.09 |                            |
 | [t1ha2_stream](doc/t1ha2_stream)      |      6376.62	|    82.41 |                            |
 | [t1ha2_atonce128](doc/t1ha2_atonce128)|     14007.67	|    50.51 |                            |
@@ -116,13 +116,11 @@ So the fastest hash functions on x86_64 without quality problems are:
 - wyhash
 - xxh3
 - t1ha
-- falkhash (_macho64 and elf64 nasm only, with HW AES extension_)
 - Metro (_but not 64crc yet, WIP_)
 - FarmHash (_not portable, too machine specific: 64 vs 32bit, old gcc, ..._)
 - Spooky32
 - fasthash
-- City (_deprecated_)
-- mum (_machine specific, mum: different results on 32/64-bit archs_)
+- MUM (_machine specific, mum: different results on 32/64-bit archs_)
 
 Hash functions for symbol tables or hash tables typically use 32 bit
 hashes, for databases, file systems and file checksums typically 64 or
@@ -145,7 +143,7 @@ The fast hash functions tested here are recommendable as fast for file
 digests and maybe bigger databases, but not for 32bit hash tables.  The
 "Quality problems" lead to less uniform distribution, i.e.  more collisions
 and worse performance, but are rarely related to real security attacks, just
-the 2nd sanity test against `\0` invariance is security relevant.
+the 2nd sanity zeroes test against `\0` invariance is security relevant.
 
 Other
 -----

--- a/Stats.h
+++ b/Stats.h
@@ -74,7 +74,7 @@ bool CountHighbitsCollisions ( std::vector<hashtype> & hashes, int nbHBits)
   int origBits = sizeof(hashtype) * 8;
   int shiftBy = origBits - nbHBits;
 
-  if (shiftBy <= 0) return 0;
+  if (shiftBy <= 0) return true;
 
   size_t const nbH = hashes.size();
   double expected = EstimateNbCollisions(nbH, nbHBits);

--- a/Stats.h
+++ b/Stats.h
@@ -103,6 +103,94 @@ bool CountHighbitsCollisions ( std::vector<hashtype> & hashes, int nbHBits)
   return true;
 }
 
+static int FindMinBits_TargetCollisionShare(int nbHashes, double share)
+{
+    int nb;
+    for (nb=2; nb<64; nb++) {
+        double const maxColls = (double)(1ULL << nb) * share;
+        double const nbColls = EstimateNbCollisions(nbHashes, nb);
+        if (nbColls < maxColls) return nb;
+    }
+    assert(0);
+    return nb;
+}
+
+static int FindMaxBits_TargetCollisionNb(int nbHashes, int minCollisions)
+{
+    int nb;
+    for (nb=63; nb>2; nb--) {
+        double const nbColls = EstimateNbCollisions(nbHashes, nb);
+        if (nbColls > minCollisions) return nb;
+    }
+    assert(0);
+    return nb;
+}
+
+template< typename hashtype >
+int CountNbCollisions ( std::vector<hashtype> & hashes, int nbHBits)
+{
+  int origBits = sizeof(hashtype) * 8;
+  int shiftBy = origBits - nbHBits;
+
+  assert(shiftBy > 0);
+
+  size_t const nbH = hashes.size();
+  int collcount = 0;
+
+  for (size_t hnb = 1; hnb < nbH; hnb++)
+  {
+    hashtype const h1 = hashes[hnb]   >> shiftBy;
+    hashtype const h2 = hashes[hnb-1] >> shiftBy;
+    if(h1 == h2)
+    {
+      collcount++;
+    }
+  }
+
+  return collcount;
+}
+
+template< typename hashtype >
+bool TestHighbitsCollisions ( std::vector<hashtype> & hashes)
+{
+  int origBits = sizeof(hashtype) * 8;
+
+  size_t const nbH = hashes.size();
+  int const minBits = FindMinBits_TargetCollisionShare(nbH, 0.01);
+  int const maxBits = FindMaxBits_TargetCollisionNb(nbH, 20);
+  if (maxBits >= origBits) return true;
+
+  printf("Testing collisions (high [%2i-%2i] bits) : ", minBits, maxBits);
+  double maxCollDev = 0.0;
+  int maxCollDevBits = 0;
+  int maxCollDevNb = 0;
+  double maxCollDevExp = 1.0;
+
+  for (int b = minBits; b <= maxBits; b++) {
+      int    const nbColls = CountNbCollisions(hashes, b);
+      double const expected = EstimateNbCollisions(nbH, b);
+      assert(expected > 0.0);
+      double const dev = (double)nbColls / expected;
+      if (dev > maxCollDev) {
+          maxCollDev = dev;
+          maxCollDevBits = b;
+          maxCollDevNb = nbColls;
+          maxCollDevExp = expected;
+      }
+  }
+
+  printf("worst is %2i bits : %6i/%6i (%5.2fx)",
+        maxCollDevBits, maxCollDevNb, (int)maxCollDevExp, maxCollDev);
+
+  if (maxCollDev > 2.0) {
+    printf(" !!!!! \n");
+    return false;
+  }
+
+  printf(" \n");
+  return true;
+}
+
 //-----------------------------------------------------------------------------
 
 template < class keytype, typename hashtype >
@@ -290,10 +378,14 @@ bool TestHashList ( std::vector<hashtype> & hashes, std::vector<hashtype> & coll
         result &= CountHighbitsCollisions(hashes, 256);
         result &= CountHighbitsCollisions(hashes, 128);
         result &= CountHighbitsCollisions(hashes,  64);
-        result &= CountHighbitsCollisions(hashes,  32);
 
+        /*
+        result &= CountHighbitsCollisions(hashes,  32);
         int const optimalNbBits = FindNbBitsForCollisionTarget(100, count);
         result &= CountHighbitsCollisions(hashes, optimalNbBits);
+        */
+
+        result &= TestHighbitsCollisions(hashes);
     }
   }
 

--- a/Stats.h
+++ b/Stats.h
@@ -243,7 +243,8 @@ static int FindNbBitsForCollisionTarget(int targetNbCollisions, int nbHashes)
 }
 
 template < typename hashtype >
-bool TestHashList ( std::vector<hashtype> & hashes, std::vector<hashtype> & collisions, bool testDist, bool drawDiagram )
+bool TestHashList ( std::vector<hashtype> & hashes, std::vector<hashtype> & collisions,
+                    bool testDist, bool drawDiagram, bool testHighBits = true )
 {
   bool result = true;
 
@@ -285,13 +286,15 @@ bool TestHashList ( std::vector<hashtype> & hashes, std::vector<hashtype> & coll
 
     printf("\n");
 
-    result &= CountHighbitsCollisions(hashes, 256);
-    result &= CountHighbitsCollisions(hashes, 128);
-    result &= CountHighbitsCollisions(hashes,  64);
-    result &= CountHighbitsCollisions(hashes,  32);
+    if (testHighBits) {
+        result &= CountHighbitsCollisions(hashes, 256);
+        result &= CountHighbitsCollisions(hashes, 128);
+        result &= CountHighbitsCollisions(hashes,  64);
+        result &= CountHighbitsCollisions(hashes,  32);
 
-    int const optimalNbBits = FindNbBitsForCollisionTarget(100, count);
-    result &= CountHighbitsCollisions(hashes, optimalNbBits);
+        int const optimalNbBits = FindNbBitsForCollisionTarget(100, count);
+        result &= CountHighbitsCollisions(hashes, optimalNbBits);
+    }
   }
 
 
@@ -308,11 +311,11 @@ bool TestHashList ( std::vector<hashtype> & hashes, std::vector<hashtype> & coll
 //----------
 
 template < typename hashtype >
-bool TestHashList ( std::vector<hashtype> & hashes, bool /*testColl*/, bool testDist, bool drawDiagram )
+bool TestHashList ( std::vector<hashtype> & hashes, bool /*testColl*/, bool testDist, bool drawDiagram, bool testHighBits = true )
 {
   std::vector<hashtype> collisions;
 
-  return TestHashList(hashes,collisions,testDist,drawDiagram);
+  return TestHashList(hashes, collisions, testDist, drawDiagram, testHighBits);
 }
 
 //-----------------------------------------------------------------------------

--- a/Stats.h
+++ b/Stats.h
@@ -8,6 +8,7 @@
 #include <algorithm>   // for std::sort
 #include <string.h>    // for memset
 #include <stdio.h>     // for printf
+#include <assert.h>
 
 double calcScore ( const int * bins, const int bincount, const int ballcount );
 

--- a/Types.h
+++ b/Types.h
@@ -271,7 +271,7 @@ public:
 
   bool operator < ( const Blob & k ) const
   {
-    for(size_t i = 0; i < sizeof(bytes); i++)
+    for(int i = sizeof(bytes) -1; i >= 0; i--)
     {
       if(bytes[i] < k.bytes[i]) return true;
       if(bytes[i] > k.bytes[i]) return false;
@@ -337,7 +337,7 @@ public:
   {
     Blob t = *this;
 
-    lshift(&t.bytes[0],sizeof(bytes),c);
+    lshift(&t.bytes[0], sizeof(bytes), c);
 
     return t;
   }
@@ -346,21 +346,21 @@ public:
   {
     Blob t = *this;
 
-    rshift(&t.bytes[0],sizeof(bytes),c);
+    rshift(&t.bytes[0], sizeof(bytes), c);
 
     return t;
   }
 
   Blob & operator <<= ( int c )
   {
-    lshift(&bytes[0],sizeof(bytes),c);
+    lshift(&bytes[0], sizeof(bytes), c);
 
     return *this;
   }
 
   Blob & operator >>= ( int c )
   {
-    rshift(&bytes[0],sizeof(bytes),c);
+    rshift(&bytes[0], sizeof(bytes), c);
 
     return *this;
   }

--- a/main.cpp
+++ b/main.cpp
@@ -214,7 +214,7 @@ HashInfo g_hashes[] =
 
   { xxHash32_test,        32, 0xBA88B743, "xxHash32",    "xxHash, 32-bit for x64" },
   { xxHash64_test,        64, 0x024B7CF4, "xxHash64",    "xxHash, 64-bit" },
-  { xxh3_test,            64, 0xF6FED399, "xxh3",        "xxHash v3, 64-bit" },
+  { xxh3_test,            64, 0x5921E69E, "xxh3",        "xxHash v3, 64-bit" },
   { xxh3low_test,         32, 0xECA5AAE7, "xxh3low",     "xxHash v3, 64-bit, low 32-bits part" },
   { xxh128_test,         128, 0xECA5AAE7, "xxh128",      "xxHash v3, 128-bit" },
   { xxh128low_test,       64, 0xECA5AAE7, "xxh128low",   "xxHash v3, 128-bit, low 64-bits part" },

--- a/main.cpp
+++ b/main.cpp
@@ -399,8 +399,6 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       result &= AvalancheTest< Blob<1536>,hashtype > (hash,300000);
     }
 
-    result &= AvalancheTest< Blob<9992>,hashtype > (hash,300000);
-
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
     fflush(NULL);

--- a/main.cpp
+++ b/main.cpp
@@ -142,7 +142,7 @@ HashInfo g_hashes[] =
 #else
     0x1967C625,
 #endif
-                                          "FNV2",        "wordwise FNV" },  
+                                          "FNV2",        "wordwise FNV" },
   { fletcher2,            64, 0x890767C0, "fletcher2",   "fletcher2 ZFS"},
   { fletcher4,            64, 0x47660EB7, "fletcher4",   "fletcher4 ZFS"},
   { Bernstein,            32, 0xBDB4B640, "bernstein",   "Bernstein, 32-bit" },
@@ -187,13 +187,11 @@ HashInfo g_hashes[] =
 #endif
   { mum_hash_test,        64, MUM_SEED,   "MUM",         "github.com/vnmakarov/mum-hash" },
   { mum_low_test,         32, MUM_SEED,   "MUMlow",      "github.com/vnmakarov/mum-hash" },
-  { mum_high_test,        32, MUM_SEED,   "MUMhigh",     "github.com/vnmakarov/mum-hash" },
 
   { CityHash32_test,      32, 0x5C28AD62, "City32",      "Google CityHash32WithSeed (old)" },
   { CityHash64noSeed_test,64, 0x63FC6063, "City64noSeed","Google CityHash64 without seed (default version, misses one final avalanche)" },
   { CityHash64_test,      64, 0x25A20825, "City64",      "Google CityHash64WithSeed (old)" },
   { CityHash64_low_test,  32, 0xCC5BC861, "City64low",   "Google CityHash64WithSeed (low 32-bits)" },
-  { CityHash64_high_test, 32, 0xC94A0E6B, "City64high",  "Google CityHash64WithSeed (high 32-bits)" },
 #if defined(__SSE4_2__) && defined(__x86_64__)
   { CityHash128_test,    128, 0x6531F54E, "City128",     "Google CityHash128WithSeed (old)" },
   { CityHashCrc128_test, 128, 0xD4389C97, "CityCrc128",  "Google CityHashCrc128WithSeed SSE4.2 (old)" },
@@ -218,10 +216,8 @@ HashInfo g_hashes[] =
   { xxHash64_test,        64, 0x024B7CF4, "xxHash64",    "xxHash, 64-bit" },
   { xxh3_test,            64, 0xF6FED399, "xxh3",        "xxHash v3, 64-bit" },
   { xxh3low_test,         32, 0xECA5AAE7, "xxh3low",     "xxHash v3, 64-bit, low 32-bits part" },
-  { xxh3high_test,        32, 0xECA5AAE7, "xxh3high",    "xxHash v3, 64-bit, high 32-bits part" },
   { xxh128_test,         128, 0xECA5AAE7, "xxh128",      "xxHash v3, 128-bit" },
   { xxh128low_test,       64, 0xECA5AAE7, "xxh128low",   "xxHash v3, 128-bit, low 64-bits part" },
-  { xxh128high_test,      64, 0xECA5AAE7, "xxh128high",  "xxHash v3, 128-bit, high 64-bits part" },
 #if 0
   { xxhash256_test,       64, 0x024B7CF4, "xxhash256",   "xxhash256, 64-bit unportable" },
 #endif
@@ -403,6 +399,8 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       result &= AvalancheTest< Blob<1536>,hashtype > (hash,300000);
     }
 
+    result &= AvalancheTest< Blob<9992>,hashtype > (hash,300000);
+
     if(!result) printf("*********FAIL*********\n");
     printf("\n");
     fflush(NULL);
@@ -485,7 +483,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       uint32_t blocks[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
 
       result &= CombinationKeyTest<hashtype>(hash,7,blocks,sizeof(blocks) / sizeof(uint32_t),
@@ -501,7 +499,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       uint32_t blocks[] =
       {
         0x00000000,
@@ -520,7 +518,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       printf("Combination Hi-Lo Tests:\n");
 
       bool result = true;
-     
+
       uint32_t blocks[] =
       {
         0x00000000,
@@ -541,7 +539,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       uint32_t blocks[] =
       {
         0x00000000,
@@ -560,7 +558,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       printf("Combination 0x0000001 Tests:\n");
 
       bool result = true;
-     
+
       uint32_t blocks[] =
       {
         0x00000000,
@@ -580,7 +578,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       uint64_t blocks[] =
       {
         0x0000000000000000ULL,
@@ -600,7 +598,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       uint64_t blocks[] =
       {
         0x0000000000000000ULL,
@@ -620,7 +618,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       block16 blocks[2];
       memset(blocks, 0, sizeof(blocks));
       blocks[0].c[0] = 1;   // presumes little endian
@@ -637,7 +635,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       size_t const nbElts = 2;
       block16 blocks[nbElts];
       memset(blocks, 0, sizeof(blocks));
@@ -655,7 +653,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       block32 blocks[2];
       memset(blocks, 0, sizeof(blocks));
       blocks[0].c[0] = 1;   // presumes little endian
@@ -672,7 +670,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       size_t const nbElts = 2;
       block32 blocks[nbElts];
       memset(blocks, 0, sizeof(blocks));
@@ -690,7 +688,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       block64 blocks[2];
       memset(blocks, 0, sizeof(blocks));
       blocks[0].c[0] = 1;   // presumes little endian
@@ -707,7 +705,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       size_t const nbElts = 2;
       block64 blocks[nbElts];
       memset(blocks, 0, sizeof(blocks));
@@ -725,7 +723,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       block128 blocks[2];
       memset(blocks, 0, sizeof(blocks));
       blocks[0].c[0] = 1;   // presumes little endian
@@ -742,7 +740,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
       fflush(NULL);
 
       bool result = true;
-     
+
       size_t const nbElts = 2;
       block128 blocks[nbElts];
       memset(blocks, 0, sizeof(blocks));
@@ -772,7 +770,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     bool result = true;
     bool testCollision = true;
     bool testDistribution = g_testExtra;
-   
+
     result &= WindowedKeyTest< Blob<hashbits*2+2>, hashtype >
       ( hash, 20, testCollision, testDistribution, g_drawDiagram );
 
@@ -791,7 +789,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     fflush(NULL);
 
     bool result = true;
-   
+
 #if 0
     result &= CyclicKeyTest<hashtype>(hash,sizeof(hashtype)+0,8,100000, g_drawDiagram);
 #else
@@ -845,7 +843,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     printf("[[[ Keyset 'Text' Tests ]]]\n\n");
 
     bool result = true;
-   
+
     const char * alnum = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
     result &= TextKeyTest( hash, "Foo",    alnum, 4, "Bar",    g_drawDiagram );
@@ -865,7 +863,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     printf("[[[ Keyset 'Zeroes' Tests ]]]\n\n");
 
     bool result = true;
-   
+
     result &= ZeroKeyTest<hashtype>( hash, g_drawDiagram );
 
     if(!result) printf("*********FAIL*********\n");
@@ -881,7 +879,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     printf("[[[ Keyset 'Seed' Tests ]]]\n\n");
 
     bool result = true;
-   
+
     result &= SeedTest<hashtype>( hash, 5000000, g_drawDiagram );
 
     if(!result) printf("*********FAIL*********\n");

--- a/xxhash.c
+++ b/xxhash.c
@@ -32,6 +32,7 @@
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 
+
 /* *************************************
 *  Tuning parameters
 ***************************************/
@@ -100,9 +101,32 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
 
 #include <assert.h>   /* assert */
 
-#define XXH_EXPORT
 #define XXH_STATIC_LINKING_ONLY
 #include "xxhash.h"
+
+
+/* *************************************
+*  Compiler Specific Options
+***************************************/
+#ifdef _MSC_VER    /* Visual Studio */
+#  pragma warning(disable : 4127)      /* disable: C4127: conditional expression is constant */
+#  define XXH_FORCE_INLINE static __forceinline
+#  define XXH_NO_INLINE static __declspec(noinline)
+#else
+#  if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+#    ifdef __GNUC__
+#      define XXH_FORCE_INLINE static inline __attribute__((always_inline))
+#      define XXH_NO_INLINE static __attribute__((noinline))
+#    else
+#      define XXH_FORCE_INLINE static inline
+#      define XXH_NO_INLINE static
+#    endif
+#  else
+#    define XXH_FORCE_INLINE static
+#    define XXH_NO_INLINE static
+#  endif /* __STDC_VERSION__ */
+#endif
+
 
 /* *************************************
 *  Basic Types

--- a/xxhash.h
+++ b/xxhash.h
@@ -107,10 +107,10 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 #    define XXH_PUBLIC_API static
 #  endif
 #else
-#  if defined(WIN32) && !defined(__GNUC__)
+#  if defined(WIN32) && defined(_MSC_VER) && (defined(XXH_IMPORT) || defined(XXH_EXPORT))
 #    ifdef XXH_EXPORT
 #      define XXH_PUBLIC_API __declspec(dllexport)
-#    else
+#    elif XXH_IMPORT
 #      define XXH_PUBLIC_API __declspec(dllimport)
 #    endif
 #  else


### PR DESCRIPTION
SMHasher tests have a good size for 32-bit hashes : they generate enough collisions to be measured, and compared to an "ideal" target.

However, when testing a large hash, 64-bits or more, all collisions results must basically be zero.
This is a minimum required, but not enough.
The tool does not allow to make a distinction between a collision ratio of 0.1% and 0.0001%.

To counter-balance this limitation, I [suggested a few years ago](http://fastcompression.blogspot.com/2014/07/xxhash-wider-64-bits.html) to also check the hash "per part", effectively cutting it into smaller 32-bit slices which get individually validated. 
For this objective, I created a few additional variants "high" and "low" for some large hashes.

This is all manual unfortunately, and tedious.

In this patch, I propose to automate the verification of partial hashes, directly into the collision analyzer. Given a 128-bits hash, it will automatically verify the high 64-bit. Given a 64-bits hash, it will automatically check the high 32-bit too.  etc.

It also verifies the high `N` bits, with `N` selected so that the number of expected collisions remains within 20 and 100, ensuring we check the largest amount of bits while still comparing the collision rate against a meaningful target.

Here is a sample of how it presents : 

```
--- Testing xxh128 "xxHash v3, 128-bit"

[[[ Keyset 'Sparse' Tests ]]]

Keyset 'Sparse' - 16-bit keys with up to 9 bits set - 50643 keys
Testing collisions (     128-bit)  - Expected     0.00, actual      0 ( 0.00x)
Testing collisions (high  64-bit)  - Expected     0.00, actual      0 ( 0.00x)
Testing collisions (high  32-bit)  - Expected     0.30, actual      0 ( 0.00x)
Testing collisions (high  24-bit)  - Expected    76.43, actual     73 ( 0.96x)
Testing distribution - Worst bias is the  13-bit window at bit  56 - 0.637%

Keyset 'Sparse' - 24-bit keys with up to 8 bits set - 1271626 keys
Testing collisions (     128-bit)  - Expected     0.00, actual      0 ( 0.00x)
Testing collisions (high  64-bit)  - Expected     0.00, actual      0 ( 0.00x)
Testing collisions (high  32-bit)  - Expected   188.25, actual    195 ( 1.04x)
Testing collisions (high  33-bit)  - Expected    94.12, actual     92 ( 0.98x)
Testing distribution - Worst bias is the  17-bit window at bit  99 - 0.098%

Keyset 'Sparse' - 32-bit keys with up to 7 bits set - 4514873 keys
Testing collisions (     128-bit)  - Expected     0.00, actual      0 ( 0.00x)
Testing collisions (high  64-bit)  - Expected     0.00, actual      0 ( 0.00x)
Testing collisions (high  32-bit)  - Expected  2373.02, actual   2400 ( 1.01x)
Testing collisions (high  37-bit)  - Expected    74.16, actual     71 ( 0.96x)
```

This is supposed to give more signal on the capability of a hash algorithm to respect the birthday theorem, hence its quality when extracting a sub-field of bits from the hash.
It also makes it possible to remove all "high" variants from the list of hashes, reducing the nb of hashes to maintain.
Another advantage is that this test is actually very fast. The largest costs are, in order, testing distribution, sorting the hashes, and generating the hashes. Counting collisions is, in comparison, a trivial task, achieved in a fraction of a second. As the high-bits test re-use all 3 elements from the first test, it's completed with very little delay.

A limitation of the current system is that it only tests high bits.
This limitation is accepted for the benefit of speed, in order to keep the same hash list which has already been sorted. In order to analyze collisions for non-high bits, it would require to modify the hast list and sort it again. This would cost more time.

As a consequence, the "low bits" variants remain present in the list of hashes.