### PR TITLE
wyhash_v3 update

### DIFF
--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -9,10 +9,8 @@
 
 #include <unordered_map>
 #include <functional>
-#include "flat_hash_map/bytell_hash_map.hpp"
 
-//typedef std::unordered_map<std::string, int,
-typedef ska::bytell_hash_map<std::string, int,
+typedef std::unordered_map<std::string, int,
   std::function<size_t (const std::string &key)>> string_hashmap;
 
 //-----------------------------------------------------------------------------

--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -9,8 +9,10 @@
 
 #include <unordered_map>
 #include <functional>
+#include "flat_hash_map/bytell_hash_map.hpp"
 
-typedef std::unordered_map<std::string, int,
+//typedef std::unordered_map<std::string, int,
+typedef ska::bytell_hash_map<std::string, int,
   std::function<size_t (const std::string &key)>> string_hashmap;
 
 //-----------------------------------------------------------------------------
@@ -317,10 +319,10 @@ double HashMapSpeedTest ( pfHash pfhash, int hashbits,
     int i = 0;
     begin = rdtsc();
     for (it = words.begin(); it != words.end(); it++, i++) {
-      std::string line = *it;
-      hashmap[line] = 1;
+  //    std::string line = *it;
+      hashmap[*it] = 1;
       if (i % 100 == 0)
-        hashmap.erase(line);
+        hashmap.erase(*it);
     }
     end = rdtsc();
     t1 = (double)(end - begin) / (double)words.size();
@@ -335,8 +337,8 @@ double HashMapSpeedTest ( pfHash pfhash, int hashbits,
       begin = rdtsc();
       for ( it = words.begin(); it != words.end(); it++, i++ )
         {
-          std::string line = *it;
-          if (hashmap[line])
+         // std::string line = *it;
+          if (hashmap[*it])
             found++;
         }
       end = rdtsc();
@@ -350,5 +352,4 @@ double HashMapSpeedTest ( pfHash pfhash, int hashbits,
   //hashmap.~unordered_map();
   return CalcMean(times);
 }
-
 //-----------------------------------------------------------------------------

--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -346,8 +346,9 @@ double HashMapSpeedTest ( pfHash pfhash, int hashbits,
   hashmap.clear();
 
   std::sort(times.begin(),times.end());
-  FilterOutliers(times);
+//  FilterOutliers(times);
   //hashmap.~unordered_map();
-  return CalcMean(times);
+ // return CalcMean(times);
+	return	times[times.size()/2];	//	median is robust, belive me, a statistician :-)
 }
 //-----------------------------------------------------------------------------

--- a/wyhash.h
+++ b/wyhash.h
@@ -28,11 +28,12 @@ static	inline	uint64_t	wyhash(const void* key,	uint64_t	len,	uint64_t	seed) {
 	if(!len)	return	0;
 	const	uint8_t	*p=(const	uint8_t*)key;	uint64_t	see1=seed,	i=len;
 	for(;i>32;i-=32,p+=32){	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+24)^see1^_wyp3);	}
-	if(i<4)	return	_wymum(len^_wyp4,_wymum(_wyr3(p,i)^seed^_wyp0,seed^_wyp1));
-	if(i<=8)	return	_wymum(len^_wyp4,_wymum(_wyr4(p)^seed^_wyp0,_wyr4(p+i-4)^seed^_wyp1));
-	if(i<=16)	return	_wymum(len^_wyp4,_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+i-8)^seed^_wyp1));
-	if(i<=24)	return	_wymum(len^_wyp4,_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1)^_wymum(_wyr8(p+i-8)^see1^_wyp2,see1^_wyp3));
-	return	_wymum(len^_wyp4,_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1)^_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+i-8)^see1^_wyp3));
+	if(i<4)	seed=_wymum(_wyr3(p,i)^seed^_wyp0,seed^_wyp1);
+	else	if(i<=8)	seed=_wymum(_wyr4(p)^seed^_wyp0,_wyr4(p+i-4)^seed^_wyp1);
+	else	if(i<=16)	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+i-8)^seed^_wyp1);
+	else	if(i<=24){	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+i-8)^see1^_wyp2,see1^_wyp3);	}
+	else{	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+i-8)^see1^_wyp3);	}
+	return	_wymum(seed^see1,len^_wyp4);
 }
 static	inline	uint64_t	wyhash64(uint64_t	A, uint64_t	B) {	return	_wymum(_wymum(A^_wyp0,	B^_wyp1),	_wyp2);}
 static	inline	double	wy2u01(uint64_t	r) {	const	double	_wynorm=1.0/(1ull<<52);	return	(r&0x000fffffffffffffull)*_wynorm;}

--- a/wyhash.h
+++ b/wyhash.h
@@ -7,13 +7,6 @@
 #include <intrin.h>
 #pragma	intrinsic(_umul128)
 #endif
-#ifndef UNLIKELY
-	#if defined(__GNUC__) || defined(__INTEL_COMPILER)
-		#define UNLIKELY(x) (__builtin_expect(!!(x), 0))
-	#else
-		#define UNLIKELY(x) (x)
-	#endif
-#endif
 const	uint64_t	_wyp0=0xa0761d6478bd642full,	_wyp1=0xe7037ed1a0b428dbull,	_wyp2=0x8ebc6af09c88c6e3ull,	_wyp3=0x589965cc75374cc3ull,	_wyp4=0x1d8e4e27c47d124full;
 static	inline	uint64_t	_wymum(uint64_t	A,	uint64_t	B) {
 #ifdef __SIZEOF_INT128__
@@ -28,70 +21,21 @@ static	inline	uint64_t	_wymum(uint64_t	A,	uint64_t	B) {
 	lo=t+(rm1<<32);	c+=lo<t;	hi=rh+(rm0>>32)+(rm1>>32)+c;	return hi^lo;
 #endif
 }
-static	inline	uint64_t	_wymix0(uint64_t	A,	uint64_t	B,	uint64_t	seed) {	return	_wymum(A^seed^_wyp0,	B^seed^_wyp1);}
-static	inline	uint64_t	_wymix1(uint64_t	A,	uint64_t	B,	uint64_t	seed) {	return	_wymum(A^seed^_wyp2,	B^seed^_wyp3);}
-static	inline	uint64_t	_wymix2(uint64_t	A,	uint64_t	B,	uint64_t	seed) {	return	_wymum(A^seed^_wyp3,	B^seed^_wyp0);}
-static	inline	uint64_t	_wymix3(uint64_t	A,	uint64_t	B,	uint64_t	seed) {	return	_wymum(A^seed^_wyp1,	B^seed^_wyp2);}
-static	inline	uint64_t	_wyr1(const	uint8_t	*p) {	uint8_t v;	memcpy(&v,	p,	1);	return	v;}
-static	inline	uint64_t	_wyr2(const	uint8_t	*p) {	uint16_t v;	memcpy(&v,	p,	2);	return	v;}
-static	inline	uint64_t	_wyr3(const	uint8_t	*p) {	return	(_wyr2(p)<<8)|_wyr1(p+2);}
 static	inline	uint64_t	_wyr4(const	uint8_t	*p) {	uint32_t v;	memcpy(&v,	p,	4);	return	v;}
-static	inline	uint64_t	_wyr5(const	uint8_t	*p) {	return	(_wyr4(p)<<8)|_wyr1(p+4);}
-static	inline	uint64_t	_wyr6(const	uint8_t	*p) {	return	(_wyr4(p)<<16)|_wyr2(p+4);}
-static	inline	uint64_t	_wyr7(const	uint8_t	*p) {	return	(_wyr4(p)<<24)|(_wyr2(p+4)<<8)|_wyr1(p+6);}
 static	inline	uint64_t	_wyr8(const	uint8_t	*p) {	return	(_wyr4(p)<<32)|_wyr4(p+4);}
+static	inline	uint64_t	_wyr3(const	uint8_t	*p,	unsigned	k){	return	(((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];	}
 static	inline	uint64_t	__wyr8(const	uint8_t	*p) {	uint64_t v;	memcpy(&v,	p,	8);	return	v;}
 //to avoid attacks, seed should be initialized as a secret.
 static	inline	uint64_t	wyhash(const void* key,	uint64_t	len,	uint64_t	seed) {
-#ifdef	WYHASH_UNSAFE
-	const   uint64_t    *q=(const   uint64_t*)key;
-	if(len<=8)	return	_wymum(len^_wyp4,_wymum((q[0]<<((8-(len&7))<<3))^seed^_wyp0,seed^_wyp1));	
-	if(len<=16)	return	_wymum(len^_wyp4,_wymum(q[0]^seed^_wyp0,(q[1]<<((8-(len&7))<<3))^seed^_wyp1));
-	if(len<=24)	return	_wymum(len^_wyp4,_wymum(q[0]^seed^_wyp0,q[1]^seed^_wyp1)^_wymum((q[2]<<((8-(len&7))<<3))^seed^_wyp2,seed^_wyp3));
-	if(len<=32)	return	_wymum(len^_wyp4,_wymum(q[0]^seed^_wyp0,q[1]^seed^_wyp1)^_wymum(q[2]^seed^_wyp2,(q[3]<<((8-(len&7))<<3))^seed^_wyp3));
-#endif
-	const	uint8_t	*p=(const	uint8_t*)key;	uint64_t i,	see1=seed,see2=seed,see3=seed;
-	for(i=0;	UNLIKELY(i+128<=len);	i+=128,	p+=128) {
-		seed=_wymix0(__wyr8(p),__wyr8(p+8),seed);	see1=_wymix1(__wyr8(p+16),__wyr8(p+24),see1);	
-		see2=_wymix2(__wyr8(p+32),__wyr8(p+40),see2);	see3=_wymix3(__wyr8(p+48),__wyr8(p+56),see3);
-		seed=_wymix0(__wyr8(p+64),__wyr8(p+72),seed);	see1=_wymix1(__wyr8(p+80),__wyr8(p+88),see1);	
-		see2=_wymix2(__wyr8(p+96),__wyr8(p+104),see2);	see3=_wymix3(__wyr8(p+112),__wyr8(p+120),see3);
-	}
-	for(;	UNLIKELY(i+32<=len);	i+=32,	p+=32) {	seed=_wymix0(__wyr8(p),__wyr8(p+8),seed);	see1=_wymix1(__wyr8(p+16),__wyr8(p+24),see1);	}
-	switch(len&31) {
-	case	1:	seed=_wymix0(_wyr1(p),0,seed);	break;
-	case	2:	seed=_wymix0(_wyr2(p),0,seed);	break;
-	case	3:	seed=_wymix0(_wyr3(p),0,seed);	break;
-	case	4:	seed=_wymix0(_wyr4(p),0,seed);		break;
-	case	5:	seed=_wymix0(_wyr5(p),0,seed);	break;
-	case	6:	seed=_wymix0(_wyr6(p),0,seed);	break;
-	case	7:	seed=_wymix0(_wyr7(p),0,seed);	break;
-	case	8:	seed=_wymix0(_wyr8(p),0,seed);	break;
-	case	9:	seed=_wymix0(_wyr8(p),_wyr1(p+8),seed);	break;
-	case	10:	seed=_wymix0(_wyr8(p),_wyr2(p+8),seed);	break;
-	case	11:	seed=_wymix0(_wyr8(p),_wyr3(p+8),seed);	break;
-	case	12:	seed=_wymix0(_wyr8(p),_wyr4(p+8),seed);	break;
-	case	13:	seed=_wymix0(_wyr8(p),_wyr5(p+8),seed);	break;
-	case	14:	seed=_wymix0(_wyr8(p),_wyr6(p+8),seed);	break;
-	case	15:	seed=_wymix0(_wyr8(p),_wyr7(p+8),seed);	break;
-	case	16:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	break;
-	case	17:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr1(p+16),0,see1);	break;
-	case	18:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr2(p+16),0,see1);	break;
-	case	19:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr3(p+16),0,see1);	break;
-	case	20:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr4(p+16),0,see1);	break;
-	case	21:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr5(p+16),0,see1);	break;
-	case	22:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr6(p+16),0,see1);	break;
-	case	23:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr7(p+16),0,see1);	break;
-	case	24:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),0,see1);	break;
-	case	25:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),_wyr1(p+24),see1);	break;
-	case	26:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),_wyr2(p+24),see1);	break;
-	case	27:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),_wyr3(p+24),see1);	break;
-	case	28:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),_wyr4(p+24),see1);	break;
-	case	29:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),_wyr5(p+24),see1);	break;
-	case	30:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),_wyr6(p+24),see1);	break;
-	case	31:	seed=_wymix0(_wyr8(p),_wyr8(p+8),seed);	see1=_wymix1(_wyr8(p+16),_wyr7(p+24),see1);	break;
-	}
-	return	_wymum(seed^see1^see2,see3^len^_wyp4);
+	if(!len)	return	0;
+	const	uint8_t	*p=(const	uint8_t*)key;	uint64_t	see1=seed,	i=len;
+	for(;	i>32;	i-=32,	p+=32) {	seed=_wymum(__wyr8(p)^seed^_wyp0,__wyr8(p+8)^seed^_wyp1);	see1=_wymum(__wyr8(p+16)^see1^_wyp2,__wyr8(p+24)^see1^_wyp3);	}
+	if(i<4)	seed=_wymum(_wyr3(p,i)^seed^_wyp0,seed^_wyp1);
+	else	if(i<=8)	seed=_wymum(_wyr4(p)^seed^_wyp0,_wyr4(p+i-4)^seed^_wyp1);
+	else	if(i<=16)	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+i-8)^seed^_wyp1);
+	else	if(i<=24){	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+i-8)^see1^_wyp2,see1^_wyp3);	}
+	else{	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+i-8)^see1^_wyp3);	}
+	return	_wymum(seed^see1,len^_wyp4);
 }
 static	inline	uint64_t	wyhash64(uint64_t	A, uint64_t	B) {	return	_wymum(_wymum(A^_wyp0,	B^_wyp1),	_wyp2);}
 static	inline	double	wy2u01(uint64_t	r) {	const	double	_wynorm=1.0/(1ull<<52);	return	(r&0x000fffffffffffffull)*_wynorm;}

--- a/wyhash.h
+++ b/wyhash.h
@@ -25,6 +25,13 @@ static	inline	uint64_t	_wyr8(const	uint8_t	*p)	{	uint64_t v; memcpy(&v,  p,  8);
 static	inline	uint64_t	_wyr4(const	uint8_t	*p) {	uint32_t v;	memcpy(&v,	p,	4);	return	v;}
 static	inline	uint64_t	_wyr3(const	uint8_t	*p,	unsigned	k){	return	(((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];	}
 static	inline	uint64_t	wyhash(const void* key,	uint64_t	len,	uint64_t	seed) {
+#ifdef	WYHASH_EVIL_FAST
+	const   uint64_t    *q=(const   uint64_t*)key;
+	if(len<=8)	return	_wymum(len^_wyp4,_wymum((q[0]<<((8-(len&7))<<3))^seed^_wyp0,seed^_wyp1));	
+	if(len<=16)	return	_wymum(len^_wyp4,_wymum(q[0]^seed^_wyp0,(q[1]<<((8-(len&7))<<3))^seed^_wyp1));
+	if(len<=24)	return	_wymum(len^_wyp4,_wymum(q[0]^seed^_wyp0,q[1]^seed^_wyp1)^_wymum((q[2]<<((8-(len&7))<<3))^seed^_wyp2,seed^_wyp3));
+	if(len<=32)	return	_wymum(len^_wyp4,_wymum(q[0]^seed^_wyp0,q[1]^seed^_wyp1)^_wymum(q[2]^seed^_wyp2,(q[3]<<((8-(len&7))<<3))^seed^_wyp3));
+#endif
 	if(!len)	return	0;
 	const	uint8_t	*p=(const	uint8_t*)key;	uint64_t	see1=seed,	i=len;
 	for(;i>32;i-=32,p+=32){	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+24)^see1^_wyp3);	}

--- a/wyhash.h
+++ b/wyhash.h
@@ -21,21 +21,18 @@ static	inline	uint64_t	_wymum(uint64_t	A,	uint64_t	B) {
 	lo=t+(rm1<<32);	c+=lo<t;	hi=rh+(rm0>>32)+(rm1>>32)+c;	return hi^lo;
 #endif
 }
+static	inline	uint64_t	_wyr8(const	uint8_t	*p)	{	uint64_t v; memcpy(&v,  p,  8); return  v;}
 static	inline	uint64_t	_wyr4(const	uint8_t	*p) {	uint32_t v;	memcpy(&v,	p,	4);	return	v;}
-static	inline	uint64_t	_wyr8(const	uint8_t	*p) {	return	(_wyr4(p)<<32)|_wyr4(p+4);}
 static	inline	uint64_t	_wyr3(const	uint8_t	*p,	unsigned	k){	return	(((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];	}
-static	inline	uint64_t	__wyr8(const	uint8_t	*p) {	uint64_t v;	memcpy(&v,	p,	8);	return	v;}
-//to avoid attacks, seed should be initialized as a secret.
 static	inline	uint64_t	wyhash(const void* key,	uint64_t	len,	uint64_t	seed) {
 	if(!len)	return	0;
 	const	uint8_t	*p=(const	uint8_t*)key;	uint64_t	see1=seed,	i=len;
-	for(;	i>32;	i-=32,	p+=32) {	seed=_wymum(__wyr8(p)^seed^_wyp0,__wyr8(p+8)^seed^_wyp1);	see1=_wymum(__wyr8(p+16)^see1^_wyp2,__wyr8(p+24)^see1^_wyp3);	}
-	if(i<4)	seed=_wymum(_wyr3(p,i)^seed^_wyp0,seed^_wyp1);
-	else	if(i<=8)	seed=_wymum(_wyr4(p)^seed^_wyp0,_wyr4(p+i-4)^seed^_wyp1);
-	else	if(i<=16)	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+i-8)^seed^_wyp1);
-	else	if(i<=24){	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+i-8)^see1^_wyp2,see1^_wyp3);	}
-	else{	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+i-8)^see1^_wyp3);	}
-	return	_wymum(seed^see1,len^_wyp4);
+	for(;i>32;i-=32,p+=32){	seed=_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1);	see1=_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+24)^see1^_wyp3);	}
+	if(i<4)	return	_wymum(len^_wyp4,_wymum(_wyr3(p,i)^seed^_wyp0,seed^_wyp1));
+	if(i<=8)	return	_wymum(len^_wyp4,_wymum(_wyr4(p)^seed^_wyp0,_wyr4(p+i-4)^seed^_wyp1));
+	if(i<=16)	return	_wymum(len^_wyp4,_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+i-8)^seed^_wyp1));
+	if(i<=24)	return	_wymum(len^_wyp4,_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1)^_wymum(_wyr8(p+i-8)^see1^_wyp2,see1^_wyp3));
+	return	_wymum(len^_wyp4,_wymum(_wyr8(p)^seed^_wyp0,_wyr8(p+8)^seed^_wyp1)^_wymum(_wyr8(p+16)^see1^_wyp2,_wyr8(p+i-8)^see1^_wyp3));
 }
 static	inline	uint64_t	wyhash64(uint64_t	A, uint64_t	B) {	return	_wymum(_wymum(A^_wyp0,	B^_wyp1),	_wyp2);}
 static	inline	double	wy2u01(uint64_t	r) {	const	double	_wynorm=1.0/(1ull<<52);	return	(r&0x000fffffffffffffull)*_wynorm;}


### PR DESCRIPTION
Dear rurban:
  I learnt finalizing method from @Cyan4973 

 Now wyhash has faster dynamic length hash speed without using unsafe operations.

|key size | wyhash | XXH3_SCALAR| XXH3_SSE| XXH3_AVX2 | t1ha2_atonce |
| ---- | ---- | ---- | ---- | ---- | ---- |
|bulk:bytes/cycle|5.078 | 2.568|6.422|8.427|6.089|
|small:cycles/hash|22.226 |23.097 |23.097|23.097|31.609|
|hashmap:cycles/op|178.260 |182.231 |182.267|180.901|186.502|

 Cheers!

Yi