### PR TITLE
Correct bebb4185 version and sanity value

### DIFF
--- a/doc/BEBB4185.txt
+++ b/doc/BEBB4185.txt
@@ -1,68 +1,67 @@
---- Testing BEBB4185 "BEBB4185" GOOD
+-------------------------------------------------------------------------------
+--- Testing BEBB4185 "BEBB4185 64" GOOD
 
 [[[ Sanity Tests ]]]
 
-Verification value 0x66CAC5F2 ....... PASS
+Verification value 0xBEBB4185 ....... PASS
 Running sanity check 1     .......... PASS
 Running AppendedZeroesTest .......... PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  0.920 bytes/cycle - 2633.44 MiB/sec @ 3 ghz
-Alignment  6 -  0.921 bytes/cycle - 2634.01 MiB/sec @ 3 ghz
-Alignment  5 -  0.922 bytes/cycle - 2637.00 MiB/sec @ 3 ghz
-Alignment  4 -  0.921 bytes/cycle - 2633.77 MiB/sec @ 3 ghz
-Alignment  3 -  0.921 bytes/cycle - 2635.94 MiB/sec @ 3 ghz
-Alignment  2 -  0.920 bytes/cycle - 2631.53 MiB/sec @ 3 ghz
-Alignment  1 -  0.924 bytes/cycle - 2643.85 MiB/sec @ 3 ghz
-Alignment  0 -  0.977 bytes/cycle - 2796.50 MiB/sec @ 3 ghz
-Average      -  0.928 bytes/cycle - 2655.75 MiB/sec @ 3 ghz
+Alignment  7 -  1.474 bytes/cycle - 4215.77 MiB/sec @ 3 ghz
+Alignment  6 -  1.473 bytes/cycle - 4214.93 MiB/sec @ 3 ghz
+Alignment  5 -  1.473 bytes/cycle - 4215.06 MiB/sec @ 3 ghz
+Alignment  4 -  1.474 bytes/cycle - 4215.86 MiB/sec @ 3 ghz
+Alignment  3 -  1.474 bytes/cycle - 4215.79 MiB/sec @ 3 ghz
+Alignment  2 -  1.473 bytes/cycle - 4215.66 MiB/sec @ 3 ghz
+Alignment  1 -  1.474 bytes/cycle - 4215.92 MiB/sec @ 3 ghz
+Alignment  0 -  1.475 bytes/cycle - 4221.21 MiB/sec @ 3 ghz
+Average      -  1.474 bytes/cycle - 4216.28 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -   171.23 cycles/hash
-Small key speed test -    2-byte keys -   200.13 cycles/hash
-Small key speed test -    3-byte keys -   210.85 cycles/hash
-Small key speed test -    4-byte keys -   243.80 cycles/hash
-Small key speed test -    5-byte keys -   281.88 cycles/hash
-Small key speed test -    6-byte keys -   283.97 cycles/hash
-Small key speed test -    7-byte keys -   316.55 cycles/hash
-Small key speed test -    8-byte keys -   151.83 cycles/hash
-Small key speed test -    9-byte keys -   165.42 cycles/hash
-Small key speed test -   10-byte keys -   220.99 cycles/hash
-Small key speed test -   11-byte keys -   219.37 cycles/hash
-Small key speed test -   12-byte keys -   238.85 cycles/hash
-Small key speed test -   13-byte keys -   269.42 cycles/hash
-Small key speed test -   14-byte keys -   331.58 cycles/hash
-Small key speed test -   15-byte keys -   318.54 cycles/hash
-Small key speed test -   16-byte keys -   170.49 cycles/hash
-Small key speed test -   17-byte keys -   196.61 cycles/hash
-Small key speed test -   18-byte keys -   211.11 cycles/hash
-Small key speed test -   19-byte keys -   232.27 cycles/hash
-Small key speed test -   20-byte keys -   254.69 cycles/hash
-Small key speed test -   21-byte keys -   282.92 cycles/hash
-Small key speed test -   22-byte keys -   304.12 cycles/hash
-Small key speed test -   23-byte keys -   327.17 cycles/hash
-Small key speed test -   24-byte keys -   169.86 cycles/hash
-Small key speed test -   25-byte keys -   200.53 cycles/hash
-Small key speed test -   26-byte keys -   208.09 cycles/hash
-Small key speed test -   27-byte keys -   217.14 cycles/hash
-Small key speed test -   28-byte keys -   245.59 cycles/hash
-Small key speed test -   29-byte keys -   261.60 cycles/hash
-Small key speed test -   30-byte keys -   276.58 cycles/hash
-Small key speed test -   31-byte keys -   302.70 cycles/hash
-Average                                    241.480 cycles/hash
-
+Small key speed test -    1-byte keys -   138.44 cycles/hash
+Small key speed test -    2-byte keys -   157.00 cycles/hash
+Small key speed test -    3-byte keys -   172.72 cycles/hash
+Small key speed test -    4-byte keys -   195.00 cycles/hash
+Small key speed test -    5-byte keys -   214.00 cycles/hash
+Small key speed test -    6-byte keys -   229.50 cycles/hash
+Small key speed test -    7-byte keys -   252.59 cycles/hash
+Small key speed test -    8-byte keys -   119.97 cycles/hash
+Small key speed test -    9-byte keys -   132.66 cycles/hash
+Small key speed test -   10-byte keys -   151.52 cycles/hash
+Small key speed test -   11-byte keys -   173.88 cycles/hash
+Small key speed test -   12-byte keys -   194.00 cycles/hash
+Small key speed test -   13-byte keys -   217.18 cycles/hash
+Small key speed test -   14-byte keys -   240.90 cycles/hash
+Small key speed test -   15-byte keys -   259.72 cycles/hash
+Small key speed test -   16-byte keys -   135.91 cycles/hash
+Small key speed test -   17-byte keys -   156.00 cycles/hash
+Small key speed test -   18-byte keys -   170.48 cycles/hash
+Small key speed test -   19-byte keys -   190.47 cycles/hash
+Small key speed test -   20-byte keys -   207.99 cycles/hash
+Small key speed test -   21-byte keys -   230.86 cycles/hash
+Small key speed test -   22-byte keys -   250.60 cycles/hash
+Small key speed test -   23-byte keys -   269.99 cycles/hash
+Small key speed test -   24-byte keys -   135.00 cycles/hash
+Small key speed test -   25-byte keys -   156.31 cycles/hash
+Small key speed test -   26-byte keys -   164.78 cycles/hash
+Small key speed test -   27-byte keys -   167.98 cycles/hash
+Small key speed test -   28-byte keys -   181.87 cycles/hash
+Small key speed test -   29-byte keys -   192.98 cycles/hash
+Small key speed test -   30-byte keys -   207.37 cycles/hash
+Small key speed test -   31-byte keys -   230.45 cycles/hash
+Average                                    190.262 cycles/hash
 
 [[[ 'Hashmap' Speed Tests ]]]
 
 std::unordered_map
-Init std HashMapTest:     922.945 cycles/op (102401 inserts, 1% deletions)
-Running std HashMapTest:  430.637 cycles/op (38.9 stdv)
+Init std HashMapTest:     667.392 cycles/op (102401 inserts, 1% deletions)
+Running std HashMapTest:  508.590 cycles/op (28.9 stdv)
 
 greg7mdp/parallel-hashmap
-Init fast HashMapTest:    453.216 cycles/op (102401 inserts, 1% deletions)
-Running fast HashMapTest: 320.749 cycles/op (22.6 stdv)  ....... PASS
-
+Init fast HashMapTest:    509.370 cycles/op (102401 inserts, 1% deletions)
+Running fast HashMapTest: 393.058 cycles/op (26.2 stdv)  ....... PASS
 
 [[[ Avalanche Tests ]]]
 
@@ -81,7 +80,425 @@ Testing  160-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.701333%
 Testing  512-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.842667%
 Testing 1024-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.770000%
 
+[[[ Keyset 'Sparse' Tests ]]]
 
+Keyset 'Sparse' - 16-bit keys with up to 9 bits set - 50643 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected          0.6, actual      0 (0.00x)
+Testing collisions (high 19-26 bits) - Worst is 26 bits: 22/38 (0.58x)
+Testing collisions (high 12-bit) - Expected      50643.0, actual  46547 (0.92x)
+Testing collisions (high  8-bit) - Expected      50643.0, actual  50387 (0.99x) (-256)
+Testing collisions (low  32-bit) - Expected          0.6, actual      0 (0.00x)
+Testing collisions (low  19-26 bits) - Worst is 26 bits: 26/38 (0.68x)
+Testing collisions (low  12-bit) - Expected      50643.0, actual  46547 (0.92x)
+Testing collisions (low   8-bit) - Expected      50643.0, actual  50387 (0.99x) (-256)
+Testing distribution - Worst bias is the 13-bit window at bit 30 - 0.440%
+
+Keyset 'Sparse' - 24-bit keys with up to 8 bits set - 1271626 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected        376.5, actual    194 (0.52x)
+Testing collisions (high 24-36 bits) - Worst is 30 bits: 779/1505 (0.52x)
+Testing collisions (high 12-bit) - Expected    1271626.0, actual 1267530 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    1271626.0, actual 1271370 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected        376.5, actual    176 (0.47x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 13/23 (0.55x)
+Testing collisions (low  12-bit) - Expected    1271626.0, actual 1267530 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    1271626.0, actual 1271370 (1.00x) (-256)
+Testing distribution - Worst bias is the 17-bit window at bit 44 - 0.102%
+
+Keyset 'Sparse' - 32-bit keys with up to 7 bits set - 4514873 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       4746.0, actual   2301 (0.48x)
+Testing collisions (high 26-39 bits) - Worst is 38 bits: 43/74 (0.58x)
+Testing collisions (high 12-bit) - Expected    4514873.0, actual 4510777 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    4514873.0, actual 4514617 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       4746.0, actual   2359 (0.50x)
+Testing collisions (low  26-39 bits) - Worst is 39 bits: 20/37 (0.54x)
+Testing collisions (low  12-bit) - Expected    4514873.0, actual 4510777 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    4514873.0, actual 4514617 (1.00x) (-256)
+Testing distribution - Worst bias is the 18-bit window at bit 11 - 0.053%
+
+Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       4923.4, actual   2524 (0.51x)
+Testing collisions (high 26-39 bits) - Worst is 37 bits: 90/153 (0.58x)
+Testing collisions (high 12-bit) - Expected    4598479.0, actual 4594383 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    4598479.0, actual 4598223 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       4923.4, actual   2442 (0.50x)
+Testing collisions (low  26-39 bits) - Worst is 32 bits: 2442/4923 (0.50x)
+Testing collisions (low  12-bit) - Expected    4598479.0, actual 4594383 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    4598479.0, actual 4598223 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 60 - 0.057%
+
+Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      46927.3, actual  23217 (0.49x)
+Testing collisions (high 28-43 bits) - Worst is 43 bits: 15/22 (0.65x)
+Testing collisions (high 12-bit) - Expected   14196869.0, actual 14192773 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   14196869.0, actual 14196613 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      46927.3, actual  23394 (0.50x)
+Testing collisions (low  28-43 bits) - Worst is 43 bits: 14/22 (0.61x)
+Testing collisions (low  12-bit) - Expected   14196869.0, actual 14192773 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   14196869.0, actual 14196613 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit  2 - 0.021%
+
+Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       4139.3, actual   2034 (0.49x)
+Testing collisions (high 26-39 bits) - Worst is 37 bits: 67/129 (0.52x)
+Testing collisions (high 12-bit) - Expected    4216423.0, actual 4212327 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    4216423.0, actual 4216167 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       4139.3, actual   2087 (0.50x)
+Testing collisions (low  26-39 bits) - Worst is 39 bits: 19/32 (0.59x)
+Testing collisions (low  12-bit) - Expected    4216423.0, actual 4212327 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    4216423.0, actual 4216167 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 46 - 0.041%
+
+Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16053.7, actual   8093 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 41 bits: 25/31 (0.80x)
+Testing collisions (high 12-bit) - Expected    8303633.0, actual 8299537 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8303633.0, actual 8303377 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16053.7, actual   8075 (0.50x)
+Testing collisions (low  27-41 bits) - Worst is 41 bits: 19/31 (0.61x)
+Testing collisions (low  12-bit) - Expected    8303633.0, actual 8299537 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8303633.0, actual 8303377 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit  4 - 0.037%
+
+Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      52965.5, actual  26418 (0.50x)
+Testing collisions (high 28-43 bits) - Worst is 42 bits: 32/51 (0.62x)
+Testing collisions (high 12-bit) - Expected   15082603.0, actual 15078507 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   15082603.0, actual 15082347 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      52965.5, actual  26383 (0.50x)
+Testing collisions (low  28-43 bits) - Worst is 31 bits: 52870/105930 (0.50x)
+Testing collisions (low  12-bit) - Expected   15082603.0, actual 15078507 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   15082603.0, actual 15082347 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 23 - 0.020%
+
+Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       2802.7, actual   1409 (0.50x)
+Testing collisions (high 26-39 bits) - Worst is 34 bits: 364/700 (0.52x)
+Testing collisions (high 12-bit) - Expected    3469497.0, actual 3465401 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    3469497.0, actual 3469241 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       2802.7, actual   1392 (0.50x)
+Testing collisions (low  26-39 bits) - Worst is 39 bits: 12/21 (0.55x)
+Testing collisions (low  12-bit) - Expected    3469497.0, actual 3465401 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    3469497.0, actual 3469241 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 40 - 0.043%
+
+Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected     169446.5, actual  84745 (0.50x)
+Testing collisions (high 29-45 bits) - Worst is 44 bits: 25/41 (0.60x)
+Testing collisions (high 12-bit) - Expected   26977161.0, actual 26973065 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   26977161.0, actual 26976905 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected     169446.5, actual  84172 (0.50x)
+Testing collisions (low  29-45 bits) - Worst is 44 bits: 24/41 (0.58x)
+Testing collisions (low  12-bit) - Expected   26977161.0, actual 26973065 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   26977161.0, actual 26976905 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 13 - 0.014%
+
+Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       1820.7, actual    951 (0.52x)
+Testing collisions (high 25-38 bits) - Worst is 37 bits: 31/56 (0.54x)
+Testing collisions (high 12-bit) - Expected    2796417.0, actual 2792321 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    2796417.0, actual 2796161 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       1820.7, actual    902 (0.50x)
+Testing collisions (low  25-38 bits) - Worst is 38 bits: 17/28 (0.60x)
+Testing collisions (low  12-bit) - Expected    2796417.0, actual 2792321 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    2796417.0, actual 2796161 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 35 - 0.074%
+
+Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected     116512.9, actual  57928 (0.50x)
+Testing collisions (high 28-44 bits) - Worst is 42 bits: 60/113 (0.53x)
+Testing collisions (high 12-bit) - Expected   22370049.0, actual 22365953 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   22370049.0, actual 22369793 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected     116512.9, actual  58676 (0.50x)
+Testing collisions (low  28-44 bits) - Worst is 37 bits: 1876/3641 (0.52x)
+Testing collisions (low  12-bit) - Expected   22370049.0, actual 22365953 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   22370049.0, actual 22369793 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.016%
+
+Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected         64.1, actual     32 (0.50x)
+Testing collisions (high 23-33 bits) - Worst is 26 bits: 2101/4104 (0.51x)
+Testing collisions (high 12-bit) - Expected     524801.0, actual 520705 (0.99x) (-4096)
+Testing collisions (high  8-bit) - Expected     524801.0, actual 524545 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected         64.1, actual     31 (0.48x)
+Testing collisions (low  23-33 bits) - Worst is 23 bits: 16232/32832 (0.49x)
+Testing collisions (low  12-bit) - Expected     524801.0, actual 520705 (0.99x) (-4096)
+Testing collisions (low   8-bit) - Expected     524801.0, actual 524545 (1.00x) (-256)
+Testing distribution - Worst bias is the 16-bit window at bit  5 - 0.229%
+
+Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       1025.0, actual    513 (0.50x)
+Testing collisions (high 25-37 bits) - Worst is 37 bits: 19/32 (0.59x)
+Testing collisions (high 12-bit) - Expected    2098177.0, actual 2094081 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    2098177.0, actual 2097921 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       1025.0, actual    500 (0.49x)
+Testing collisions (low  25-37 bits) - Worst is 30 bits: 2100/4100 (0.51x)
+Testing collisions (low  12-bit) - Expected    2098177.0, actual 2094081 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    2098177.0, actual 2097921 (1.00x) (-256)
+Testing distribution - Worst bias is the 18-bit window at bit 36 - 0.077%
+
+
+[[[ Keyset 'Permutation' Tests ]]]
+
+Combination Lowbits Tests:
+Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       1337.5, actual    664 (0.50x)
+Testing collisions (high 25-38 bits) - Worst is 27 bits: 21420/42798 (0.50x)
+Testing collisions (high 12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       1337.5, actual    672 (0.50x)
+Testing collisions (low  25-38 bits) - Worst is 36 bits: 56/83 (0.67x)
+Testing collisions (low  12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
+Testing distribution - Worst bias is the 18-bit window at bit 53 - 0.063%
+
+
+Combination Highbits Tests
+Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       1337.5, actual    666 (0.50x)
+Testing collisions (high 25-38 bits) - Worst is 35 bits: 90/167 (0.54x)
+Testing collisions (high 12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       1337.5, actual    665 (0.50x)
+Testing collisions (low  25-38 bits) - Worst is 38 bits: 16/20 (0.77x)
+Testing collisions (low  12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
+Testing distribution - Worst bias is the 18-bit window at bit 19 - 0.075%
+
+
+Combination Hi-Lo Tests:
+Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      34678.6, actual  17184 (0.50x)
+Testing collisions (high 27-42 bits) - Worst is 42 bits: 24/33 (0.71x)
+Testing collisions (high 12-bit) - Expected   12204240.0, actual 12200144 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   12204240.0, actual 12203984 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      34678.6, actual  17408 (0.50x)
+Testing collisions (low  27-42 bits) - Worst is 36 bits: 1127/2167 (0.52x)
+Testing collisions (low  12-bit) - Expected   12204240.0, actual 12200144 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   12204240.0, actual 12203984 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 53 - 0.021%
+
+
+Combination 0x8000000 Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8115 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 36 bits: 524/1023 (0.51x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8242 (0.50x)
+Testing collisions (low  27-41 bits) - Worst is 38 bits: 147/255 (0.57x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 52 - 0.048%
+
+
+Combination 0x0000001 Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8112 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 34 bits: 2050/4095 (0.50x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8209 (0.50x)
+Testing collisions (low  27-41 bits) - Worst is 40 bits: 46/63 (0.72x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit  0 - 0.053%
+
+
+Combination 0x800000000000000 Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8022 (0.49x)
+Testing collisions (high 27-41 bits) - Worst is 40 bits: 32/63 (0.50x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8325 (0.51x)
+Testing collisions (low  27-41 bits) - Worst is 35 bits: 1070/2047 (0.52x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 25 - 0.040%
+
+
+Combination 0x000000000000001 Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8320 (0.51x)
+Testing collisions (high 27-41 bits) - Worst is 32 bits: 8320/16383 (0.51x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8298 (0.51x)
+Testing collisions (low  27-41 bits) - Worst is 40 bits: 36/63 (0.56x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 20 - 0.031%
+
+
+Combination 16-bytes [0-1] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8212 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 40 bits: 42/63 (0.66x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8236 (0.50x)
+Testing collisions (low  27-41 bits) - Worst is 35 bits: 1057/2047 (0.52x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 40 - 0.035%
+
+
+Combination 16-bytes [0-last] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8237 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 36 bits: 549/1023 (0.54x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8069 (0.49x)
+Testing collisions (low  27-41 bits) - Worst is 30 bits: 32799/65535 (0.50x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.027%
+
+
+Combination 32-bytes [0-1] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8143 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 36 bits: 530/1023 (0.52x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8136 (0.50x)
+Testing collisions (low  27-41 bits) - Worst is 39 bits: 73/127 (0.57x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 20 - 0.048%
+
+
+Combination 32-bytes [0-last] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8242 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 41 bits: 24/31 (0.75x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8292 (0.51x)
+Testing collisions (low  27-41 bits) - Worst is 40 bits: 37/63 (0.58x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit  9 - 0.036%
+
+
+Combination 64-bytes [0-1] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8219 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 39 bits: 71/127 (0.55x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8286 (0.51x)
+Testing collisions (low  27-41 bits) - Worst is 38 bits: 139/255 (0.54x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.036%
+
+
+Combination 64-bytes [0-last] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8071 (0.49x)
+Testing collisions (high 27-41 bits) - Worst is 41 bits: 16/31 (0.50x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8368 (0.51x)
+Testing collisions (low  27-41 bits) - Worst is 37 bits: 278/511 (0.54x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 35 - 0.028%
+
+
+Combination 128-bytes [0-1] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8285 (0.51x)
+Testing collisions (high 27-41 bits) - Worst is 41 bits: 17/31 (0.53x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8201 (0.50x)
+Testing collisions (low  27-41 bits) - Worst is 38 bits: 145/255 (0.57x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.035%
+
+
+Combination 128-bytes [0-last] Tests:
+Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      16384.0, actual   8256 (0.50x)
+Testing collisions (high 27-41 bits) - Worst is 35 bits: 1039/2047 (0.51x)
+Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      16384.0, actual   8268 (0.50x)
+Testing collisions (low  27-41 bits) - Worst is 40 bits: 38/63 (0.59x)
+Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 46 - 0.065%
+
+
+[[[ Keyset 'Window' Tests ]]]
+
+Keyset 'Window' -  32-bit key,  25-bit window - 32 tests, 33554432 keys per test
+Window at   0 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   1 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   2 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   3 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   4 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   5 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   6 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   7 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   8 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at   9 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  10 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  11 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  12 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  13 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  14 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  15 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  16 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  17 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  18 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  19 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  20 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  21 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  22 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  23 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  24 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  25 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  26 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  27 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  28 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  29 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  30 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  31 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Window at  32 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
 
 [[[ Keyset 'Cyclic' Tests ]]]
 
@@ -157,14 +574,152 @@ Testing collisions (low  12-bit) - Expected    1000000.0, actual 995904 (1.00x) 
 Testing collisions (low   8-bit) - Expected    1000000.0, actual 999744 (1.00x) (-256)
 Testing distribution - Worst bias is the 17-bit window at bit 40 - 0.116%
 
+
+[[[ Keyset 'TwoBytes' Tests ]]]
+
+Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected         99.1, actual     39 (0.39x)
+Testing collisions (high 23-34 bits) - Worst is 27 bits: 1583/3172 (0.50x)
+Testing collisions (high 12-bit) - Expected     652545.0, actual 648449 (0.99x) (-4096)
+Testing collisions (high  8-bit) - Expected     652545.0, actual 652289 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected         99.1, actual     50 (0.50x)
+Testing collisions (low  23-34 bits) - Worst is 31 bits: 128/198 (0.65x)
+Testing collisions (low  12-bit) - Expected     652545.0, actual 648449 (0.99x) (-4096)
+Testing collisions (low   8-bit) - Expected     652545.0, actual 652289 (1.00x) (-256)
+Testing distribution - Worst bias is the 16-bit window at bit 45 - 0.141%
+
+Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       6969.1, actual   3502 (0.50x)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 19/27 (0.70x)
+Testing collisions (high 12-bit) - Expected    5471025.0, actual 5466929 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    5471025.0, actual 5470769 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       6969.1, actual   3445 (0.49x)
+Testing collisions (low  26-40 bits) - Worst is 40 bits: 18/27 (0.66x)
+Testing collisions (low  12-bit) - Expected    5471025.0, actual 5466929 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    5471025.0, actual 5470769 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 39 - 0.057%
+
+Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      80695.5, actual  40349 (0.50x)
+Testing collisions (high 28-43 bits) - Worst is 42 bits: 59/78 (0.75x)
+Testing collisions (high 12-bit) - Expected   18616785.0, actual 18612689 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   18616785.0, actual 18616529 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      80695.5, actual  40425 (0.50x)
+Testing collisions (low  28-43 bits) - Worst is 43 bits: 27/39 (0.69x)
+Testing collisions (low  12-bit) - Expected   18616785.0, actual 18612689 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   18616785.0, actual 18616529 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 12 - 0.013%
+
+Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected     455926.3, actual 227235 (0.50x)
+Testing collisions (high 29-46 bits) - Worst is 46 bits: 19/27 (0.68x)
+Testing collisions (high 12-bit) - Expected   44251425.0, actual 44247329 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   44251425.0, actual 44251169 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected     455926.3, actual 227152 (0.50x)
+Testing collisions (low  29-46 bits) - Worst is 33 bits: 113821/227963 (0.50x)
+Testing collisions (low  12-bit) - Expected   44251425.0, actual 44247329 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   44251425.0, actual 44251169 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 54 - 0.005%
+
+Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected    1743569.4, actual 865893 (0.50x)
+Testing collisions (high 30-48 bits) - Worst is 48 bits: 18/26 (0.68x)
+Testing collisions (high 12-bit) - Expected   86536545.0, actual 86532449 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   86536545.0, actual 86536289 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected    1743569.4, actual 865257 (0.50x)
+Testing collisions (low  30-48 bits) - Worst is 34 bits: 217297/435892 (0.50x)
+Testing collisions (low  12-bit) - Expected   86536545.0, actual 86532449 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   86536545.0, actual 86536289 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 25 - 0.002%
+
+
+[[[ Keyset 'Text' Tests ]]]
+
+Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      50836.3, actual  25606 (0.50x)
+Testing collisions (high 28-43 bits) - Worst is 43 bits: 13/24 (0.52x)
+Testing collisions (high 12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      50836.3, actual  25188 (0.50x)
+Testing collisions (low  28-43 bits) - Worst is 30 bits: 101125/203345 (0.50x)
+Testing collisions (low  12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit  5 - 0.018%
+
+Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      50836.3, actual  25261 (0.50x)
+Testing collisions (high 28-43 bits) - Worst is 42 bits: 28/49 (0.56x)
+Testing collisions (high 12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      50836.3, actual  25174 (0.50x)
+Testing collisions (low  28-43 bits) - Worst is 39 bits: 207/397 (0.52x)
+Testing collisions (low  12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit  9 - 0.021%
+
+Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected      50836.3, actual  25539 (0.50x)
+Testing collisions (high 28-43 bits) - Worst is 43 bits: 16/24 (0.64x)
+Testing collisions (high 12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected      50836.3, actual  25460 (0.50x)
+Testing collisions (low  28-43 bits) - Worst is 43 bits: 14/24 (0.56x)
+Testing collisions (low  12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
+Testing distribution - Worst bias is the 20-bit window at bit 62 - 0.018%
+
+
+[[[ Keyset 'Zeroes' Tests ]]]
+
+Keyset 'Zeroes' - 204800 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected          9.8, actual      9 (0.92x)
+Testing collisions (high 21-30 bits) - Worst is 30 bits: 29/39 (0.74x)
+Testing collisions (high 12-bit) - Expected     204800.0, actual 200704 (0.98x)
+Testing collisions (high  8-bit) - Expected     204800.0, actual 204544 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected          9.8, actual      5 (0.51x)
+Testing collisions (low  21-30 bits) - Worst is 27 bits: 173/312 (0.55x)
+Testing collisions (low  12-bit) - Expected     204800.0, actual 200704 (0.98x)
+Testing collisions (low   8-bit) - Expected     204800.0, actual 204544 (1.00x) (-256)
+Testing distribution - Worst bias is the 15-bit window at bit 23 - 0.330%
+
+
+[[[ Keyset 'Seed' Tests ]]]
+
+Keyset 'Seed' - 5000000 keys
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       5820.8, actual   2886 (0.50x)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 12/22 (0.53x)
+Testing collisions (high 12-bit) - Expected    5000000.0, actual 4995904 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected    5000000.0, actual 4999744 (1.00x) (-256)
+Testing collisions (low  32-bit) - Expected       5820.8, actual   2927 (0.50x)
+Testing collisions (low  26-40 bits) - Worst is 38 bits: 47/90 (0.52x)
+Testing collisions (low  12-bit) - Expected    5000000.0, actual 4995904 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected    5000000.0, actual 4999744 (1.00x) (-256)
+Testing distribution - Worst bias is the 19-bit window at bit 34 - 0.038%
+
+
 [[[ Keyset 'PerlinNoise' Tests ]]]
 
 Testing 16777216 coordinates (L2) : 
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 32-bit) - Expected      65536.0, actual  32715 (0.50x)
 Testing collisions (high 28-43 bits) - Worst is 43 bits: 22/31 (0.69x)
+Testing collisions (high 12-bit) - Expected   16777216.0, actual 16773120 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   16777216.0, actual 16776960 (1.00x) (-256)
 Testing collisions (low  32-bit) - Expected      65536.0, actual  33098 (0.51x)
 Testing collisions (low  28-43 bits) - Worst is 41 bits: 81/127 (0.63x)
+Testing collisions (low  12-bit) - Expected   16777216.0, actual 16773120 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   16777216.0, actual 16776960 (1.00x) (-256)
+
 
 [[[ Diff 'Differential' Tests ]]]
 
@@ -179,6 +734,7 @@ Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 64 bit hashes.
 Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 64 bit hashes.
 1000 reps, 2796416000 total tests, expecting 0.00 random collisions..........
 0 total collisions, of which 0 single collisions were ignored
+
 
 [[[ DiffDist 'Differential Distribution' Tests ]]]
 
@@ -887,559 +1443,6 @@ Testing collisions (low  12-bit) - Expected    2097152.0, actual 2093056 (1.00x)
 Testing collisions (low   8-bit) - Expected    2097152.0, actual 2096896 (1.00x) (-256)
 
 
-[[[ Keyset 'Permutation' Tests ]]]
-
-Combination Lowbits Tests:
-Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1337.5, actual    664 (0.50x)
-Testing collisions (high 25-38 bits) - Worst is 27 bits: 21420/42798 (0.50x)
-Testing collisions (high 12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       1337.5, actual    672 (0.50x)
-Testing collisions (low  25-38 bits) - Worst is 36 bits: 56/83 (0.67x)
-Testing collisions (low  12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
-Testing distribution - Worst bias is the 18-bit window at bit 53 - 0.063%
-
-
-Combination Highbits Tests
-Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1337.5, actual    666 (0.50x)
-Testing collisions (high 25-38 bits) - Worst is 35 bits: 90/167 (0.54x)
-Testing collisions (high 12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       1337.5, actual    665 (0.50x)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 16/20 (0.77x)
-Testing collisions (low  12-bit) - Expected    2396744.0, actual 2392648 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    2396744.0, actual 2396488 (1.00x) (-256)
-Testing distribution - Worst bias is the 18-bit window at bit 19 - 0.075%
-
-
-Combination Hi-Lo Tests:
-Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      34678.6, actual  17184 (0.50x)
-Testing collisions (high 27-42 bits) - Worst is 42 bits: 24/33 (0.71x)
-Testing collisions (high 12-bit) - Expected   12204240.0, actual 12200144 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   12204240.0, actual 12203984 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      34678.6, actual  17408 (0.50x)
-Testing collisions (low  27-42 bits) - Worst is 36 bits: 1127/2167 (0.52x)
-Testing collisions (low  12-bit) - Expected   12204240.0, actual 12200144 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   12204240.0, actual 12203984 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 53 - 0.021%
-
-
-Combination 0x8000000 Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8115 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 36 bits: 524/1023 (0.51x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8242 (0.50x)
-Testing collisions (low  27-41 bits) - Worst is 38 bits: 147/255 (0.57x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 52 - 0.048%
-
-
-Combination 0x0000001 Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8112 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 34 bits: 2050/4095 (0.50x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8209 (0.50x)
-Testing collisions (low  27-41 bits) - Worst is 40 bits: 46/63 (0.72x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit  0 - 0.053%
-
-
-Combination 0x800000000000000 Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8022 (0.49x)
-Testing collisions (high 27-41 bits) - Worst is 40 bits: 32/63 (0.50x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8325 (0.51x)
-Testing collisions (low  27-41 bits) - Worst is 35 bits: 1070/2047 (0.52x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 25 - 0.040%
-
-
-Combination 0x000000000000001 Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8320 (0.51x)
-Testing collisions (high 27-41 bits) - Worst is 32 bits: 8320/16383 (0.51x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8298 (0.51x)
-Testing collisions (low  27-41 bits) - Worst is 40 bits: 36/63 (0.56x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 20 - 0.031%
-
-
-Combination 16-bytes [0-1] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8212 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 40 bits: 42/63 (0.66x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8236 (0.50x)
-Testing collisions (low  27-41 bits) - Worst is 35 bits: 1057/2047 (0.52x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 40 - 0.035%
-
-
-Combination 16-bytes [0-last] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8237 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 36 bits: 549/1023 (0.54x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8069 (0.49x)
-Testing collisions (low  27-41 bits) - Worst is 30 bits: 32799/65535 (0.50x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.027%
-
-
-Combination 32-bytes [0-1] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8143 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 36 bits: 530/1023 (0.52x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8136 (0.50x)
-Testing collisions (low  27-41 bits) - Worst is 39 bits: 73/127 (0.57x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 20 - 0.048%
-
-
-Combination 32-bytes [0-last] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8242 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 41 bits: 24/31 (0.75x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8292 (0.51x)
-Testing collisions (low  27-41 bits) - Worst is 40 bits: 37/63 (0.58x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit  9 - 0.036%
-
-
-Combination 64-bytes [0-1] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8219 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 39 bits: 71/127 (0.55x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8286 (0.51x)
-Testing collisions (low  27-41 bits) - Worst is 38 bits: 139/255 (0.54x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.036%
-
-
-Combination 64-bytes [0-last] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8071 (0.49x)
-Testing collisions (high 27-41 bits) - Worst is 41 bits: 16/31 (0.50x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8368 (0.51x)
-Testing collisions (low  27-41 bits) - Worst is 37 bits: 278/511 (0.54x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 35 - 0.028%
-
-
-Combination 128-bytes [0-1] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8285 (0.51x)
-Testing collisions (high 27-41 bits) - Worst is 41 bits: 17/31 (0.53x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8201 (0.50x)
-Testing collisions (low  27-41 bits) - Worst is 38 bits: 145/255 (0.57x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.035%
-
-
-Combination 128-bytes [0-last] Tests:
-Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16384.0, actual   8256 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 35 bits: 1039/2047 (0.51x)
-Testing collisions (high 12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16384.0, actual   8268 (0.50x)
-Testing collisions (low  27-41 bits) - Worst is 40 bits: 38/63 (0.59x)
-Testing collisions (low  12-bit) - Expected    8388606.0, actual 8384510 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8388606.0, actual 8388350 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 46 - 0.065%
-
-
-[[[ Keyset 'Seed' Tests ]]]
-
-Keyset 'Seed' - 5000000 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       5820.8, actual   2886 (0.50x)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 12/22 (0.53x)
-Testing collisions (high 12-bit) - Expected    5000000.0, actual 4995904 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    5000000.0, actual 4999744 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       5820.8, actual   2927 (0.50x)
-Testing collisions (low  26-40 bits) - Worst is 38 bits: 47/90 (0.52x)
-Testing collisions (low  12-bit) - Expected    5000000.0, actual 4995904 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    5000000.0, actual 4999744 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 34 - 0.038%
-
-
-
-[[[ Keyset 'Sparse' Tests ]]]
-
-Keyset 'Sparse' - 16-bit keys with up to 9 bits set - 50643 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          0.6, actual      0 (0.00x)
-Testing collisions (high 19-26 bits) - Worst is 26 bits: 22/38 (0.58x)
-Testing collisions (high 12-bit) - Expected      50643.0, actual  46547 (0.92x)
-Testing collisions (high  8-bit) - Expected      50643.0, actual  50387 (0.99x) (-256)
-Testing collisions (low  32-bit) - Expected          0.6, actual      0 (0.00x)
-Testing collisions (low  19-26 bits) - Worst is 26 bits: 26/38 (0.68x)
-Testing collisions (low  12-bit) - Expected      50643.0, actual  46547 (0.92x)
-Testing collisions (low   8-bit) - Expected      50643.0, actual  50387 (0.99x) (-256)
-Testing distribution - Worst bias is the 13-bit window at bit 30 - 0.440%
-
-Keyset 'Sparse' - 24-bit keys with up to 8 bits set - 1271626 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        376.5, actual    194 (0.52x)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 779/1505 (0.52x)
-Testing collisions (high 12-bit) - Expected    1271626.0, actual 1267530 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    1271626.0, actual 1271370 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected        376.5, actual    176 (0.47x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 13/23 (0.55x)
-Testing collisions (low  12-bit) - Expected    1271626.0, actual 1267530 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    1271626.0, actual 1271370 (1.00x) (-256)
-Testing distribution - Worst bias is the 17-bit window at bit 44 - 0.102%
-
-Keyset 'Sparse' - 32-bit keys with up to 7 bits set - 4514873 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       4746.0, actual   2301 (0.48x)
-Testing collisions (high 26-39 bits) - Worst is 38 bits: 43/74 (0.58x)
-Testing collisions (high 12-bit) - Expected    4514873.0, actual 4510777 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    4514873.0, actual 4514617 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       4746.0, actual   2359 (0.50x)
-Testing collisions (low  26-39 bits) - Worst is 39 bits: 20/37 (0.54x)
-Testing collisions (low  12-bit) - Expected    4514873.0, actual 4510777 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    4514873.0, actual 4514617 (1.00x) (-256)
-Testing distribution - Worst bias is the 18-bit window at bit 11 - 0.053%
-
-Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       4923.4, actual   2524 (0.51x)
-Testing collisions (high 26-39 bits) - Worst is 37 bits: 90/153 (0.58x)
-Testing collisions (high 12-bit) - Expected    4598479.0, actual 4594383 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    4598479.0, actual 4598223 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       4923.4, actual   2442 (0.50x)
-Testing collisions (low  26-39 bits) - Worst is 32 bits: 2442/4923 (0.50x)
-Testing collisions (low  12-bit) - Expected    4598479.0, actual 4594383 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    4598479.0, actual 4598223 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 60 - 0.057%
-
-Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      46927.3, actual  23217 (0.49x)
-Testing collisions (high 28-43 bits) - Worst is 43 bits: 15/22 (0.65x)
-Testing collisions (high 12-bit) - Expected   14196869.0, actual 14192773 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   14196869.0, actual 14196613 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      46927.3, actual  23394 (0.50x)
-Testing collisions (low  28-43 bits) - Worst is 43 bits: 14/22 (0.61x)
-Testing collisions (low  12-bit) - Expected   14196869.0, actual 14192773 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   14196869.0, actual 14196613 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit  2 - 0.021%
-
-Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       4139.3, actual   2034 (0.49x)
-Testing collisions (high 26-39 bits) - Worst is 37 bits: 67/129 (0.52x)
-Testing collisions (high 12-bit) - Expected    4216423.0, actual 4212327 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    4216423.0, actual 4216167 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       4139.3, actual   2087 (0.50x)
-Testing collisions (low  26-39 bits) - Worst is 39 bits: 19/32 (0.59x)
-Testing collisions (low  12-bit) - Expected    4216423.0, actual 4212327 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    4216423.0, actual 4216167 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 46 - 0.041%
-
-Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      16053.7, actual   8093 (0.50x)
-Testing collisions (high 27-41 bits) - Worst is 41 bits: 25/31 (0.80x)
-Testing collisions (high 12-bit) - Expected    8303633.0, actual 8299537 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    8303633.0, actual 8303377 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      16053.7, actual   8075 (0.50x)
-Testing collisions (low  27-41 bits) - Worst is 41 bits: 19/31 (0.61x)
-Testing collisions (low  12-bit) - Expected    8303633.0, actual 8299537 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    8303633.0, actual 8303377 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit  4 - 0.037%
-
-Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      52965.5, actual  26418 (0.50x)
-Testing collisions (high 28-43 bits) - Worst is 42 bits: 32/51 (0.62x)
-Testing collisions (high 12-bit) - Expected   15082603.0, actual 15078507 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   15082603.0, actual 15082347 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      52965.5, actual  26383 (0.50x)
-Testing collisions (low  28-43 bits) - Worst is 31 bits: 52870/105930 (0.50x)
-Testing collisions (low  12-bit) - Expected   15082603.0, actual 15078507 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   15082603.0, actual 15082347 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 23 - 0.020%
-
-Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2802.7, actual   1409 (0.50x)
-Testing collisions (high 26-39 bits) - Worst is 34 bits: 364/700 (0.52x)
-Testing collisions (high 12-bit) - Expected    3469497.0, actual 3465401 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    3469497.0, actual 3469241 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       2802.7, actual   1392 (0.50x)
-Testing collisions (low  26-39 bits) - Worst is 39 bits: 12/21 (0.55x)
-Testing collisions (low  12-bit) - Expected    3469497.0, actual 3465401 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    3469497.0, actual 3469241 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 40 - 0.043%
-
-Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     169446.5, actual  84745 (0.50x)
-Testing collisions (high 29-45 bits) - Worst is 44 bits: 25/41 (0.60x)
-Testing collisions (high 12-bit) - Expected   26977161.0, actual 26973065 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   26977161.0, actual 26976905 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected     169446.5, actual  84172 (0.50x)
-Testing collisions (low  29-45 bits) - Worst is 44 bits: 24/41 (0.58x)
-Testing collisions (low  12-bit) - Expected   26977161.0, actual 26973065 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   26977161.0, actual 26976905 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 13 - 0.014%
-
-Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1820.7, actual    951 (0.52x)
-Testing collisions (high 25-38 bits) - Worst is 37 bits: 31/56 (0.54x)
-Testing collisions (high 12-bit) - Expected    2796417.0, actual 2792321 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    2796417.0, actual 2796161 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       1820.7, actual    902 (0.50x)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 17/28 (0.60x)
-Testing collisions (low  12-bit) - Expected    2796417.0, actual 2792321 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    2796417.0, actual 2796161 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 35 - 0.074%
-
-Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     116512.9, actual  57928 (0.50x)
-Testing collisions (high 28-44 bits) - Worst is 42 bits: 60/113 (0.53x)
-Testing collisions (high 12-bit) - Expected   22370049.0, actual 22365953 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   22370049.0, actual 22369793 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected     116512.9, actual  58676 (0.50x)
-Testing collisions (low  28-44 bits) - Worst is 37 bits: 1876/3641 (0.52x)
-Testing collisions (low  12-bit) - Expected   22370049.0, actual 22365953 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   22370049.0, actual 22369793 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.016%
-
-Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected         64.1, actual     32 (0.50x)
-Testing collisions (high 23-33 bits) - Worst is 26 bits: 2101/4104 (0.51x)
-Testing collisions (high 12-bit) - Expected     524801.0, actual 520705 (0.99x) (-4096)
-Testing collisions (high  8-bit) - Expected     524801.0, actual 524545 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected         64.1, actual     31 (0.48x)
-Testing collisions (low  23-33 bits) - Worst is 23 bits: 16232/32832 (0.49x)
-Testing collisions (low  12-bit) - Expected     524801.0, actual 520705 (0.99x) (-4096)
-Testing collisions (low   8-bit) - Expected     524801.0, actual 524545 (1.00x) (-256)
-Testing distribution - Worst bias is the 16-bit window at bit  5 - 0.229%
-
-Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1025.0, actual    513 (0.50x)
-Testing collisions (high 25-37 bits) - Worst is 37 bits: 19/32 (0.59x)
-Testing collisions (high 12-bit) - Expected    2098177.0, actual 2094081 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    2098177.0, actual 2097921 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       1025.0, actual    500 (0.49x)
-Testing collisions (low  25-37 bits) - Worst is 30 bits: 2100/4100 (0.51x)
-Testing collisions (low  12-bit) - Expected    2098177.0, actual 2094081 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    2098177.0, actual 2097921 (1.00x) (-256)
-Testing distribution - Worst bias is the 18-bit window at bit 36 - 0.077%
-
-
-[[[ Keyset 'Text' Tests ]]]
-
-Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      50836.3, actual  25606 (0.50x)
-Testing collisions (high 28-43 bits) - Worst is 43 bits: 13/24 (0.52x)
-Testing collisions (high 12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      50836.3, actual  25188 (0.50x)
-Testing collisions (low  28-43 bits) - Worst is 30 bits: 101125/203345 (0.50x)
-Testing collisions (low  12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit  5 - 0.018%
-
-Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      50836.3, actual  25261 (0.50x)
-Testing collisions (high 28-43 bits) - Worst is 42 bits: 28/49 (0.56x)
-Testing collisions (high 12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      50836.3, actual  25174 (0.50x)
-Testing collisions (low  28-43 bits) - Worst is 39 bits: 207/397 (0.52x)
-Testing collisions (low  12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit  9 - 0.021%
-
-Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      50836.3, actual  25539 (0.50x)
-Testing collisions (high 28-43 bits) - Worst is 43 bits: 16/24 (0.64x)
-Testing collisions (high 12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      50836.3, actual  25460 (0.50x)
-Testing collisions (low  28-43 bits) - Worst is 43 bits: 14/24 (0.56x)
-Testing collisions (low  12-bit) - Expected   14776336.0, actual 14772240 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   14776336.0, actual 14776080 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 62 - 0.018%
-
-
-[[[ Keyset 'TwoBytes' Tests ]]]
-
-Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected         99.1, actual     39 (0.39x)
-Testing collisions (high 23-34 bits) - Worst is 27 bits: 1583/3172 (0.50x)
-Testing collisions (high 12-bit) - Expected     652545.0, actual 648449 (0.99x) (-4096)
-Testing collisions (high  8-bit) - Expected     652545.0, actual 652289 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected         99.1, actual     50 (0.50x)
-Testing collisions (low  23-34 bits) - Worst is 31 bits: 128/198 (0.65x)
-Testing collisions (low  12-bit) - Expected     652545.0, actual 648449 (0.99x) (-4096)
-Testing collisions (low   8-bit) - Expected     652545.0, actual 652289 (1.00x) (-256)
-Testing distribution - Worst bias is the 16-bit window at bit 45 - 0.141%
-
-Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       6969.1, actual   3502 (0.50x)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 19/27 (0.70x)
-Testing collisions (high 12-bit) - Expected    5471025.0, actual 5466929 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected    5471025.0, actual 5470769 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected       6969.1, actual   3445 (0.49x)
-Testing collisions (low  26-40 bits) - Worst is 40 bits: 18/27 (0.66x)
-Testing collisions (low  12-bit) - Expected    5471025.0, actual 5466929 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected    5471025.0, actual 5470769 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 39 - 0.057%
-
-Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      80695.5, actual  40349 (0.50x)
-Testing collisions (high 28-43 bits) - Worst is 42 bits: 59/78 (0.75x)
-Testing collisions (high 12-bit) - Expected   18616785.0, actual 18612689 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   18616785.0, actual 18616529 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected      80695.5, actual  40425 (0.50x)
-Testing collisions (low  28-43 bits) - Worst is 43 bits: 27/39 (0.69x)
-Testing collisions (low  12-bit) - Expected   18616785.0, actual 18612689 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   18616785.0, actual 18616529 (1.00x) (-256)
-Testing distribution - Worst bias is the 20-bit window at bit 12 - 0.013%
-
-Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     455926.3, actual 227235 (0.50x)
-Testing collisions (high 29-46 bits) - Worst is 46 bits: 19/27 (0.68x)
-Testing collisions (high 12-bit) - Expected   44251425.0, actual 44247329 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   44251425.0, actual 44251169 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected     455926.3, actual 227152 (0.50x)
-Testing collisions (low  29-46 bits) - Worst is 33 bits: 113821/227963 (0.50x)
-Testing collisions (low  12-bit) - Expected   44251425.0, actual 44247329 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   44251425.0, actual 44251169 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 54 - 0.005%
-
-Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected    1743569.4, actual 865893 (0.50x)
-Testing collisions (high 30-48 bits) - Worst is 48 bits: 18/26 (0.68x)
-Testing collisions (high 12-bit) - Expected   86536545.0, actual 86532449 (1.00x) (-4096)
-Testing collisions (high  8-bit) - Expected   86536545.0, actual 86536289 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected    1743569.4, actual 865257 (0.50x)
-Testing collisions (low  30-48 bits) - Worst is 34 bits: 217297/435892 (0.50x)
-Testing collisions (low  12-bit) - Expected   86536545.0, actual 86532449 (1.00x) (-4096)
-Testing collisions (low   8-bit) - Expected   86536545.0, actual 86536289 (1.00x) (-256)
-Testing distribution - Worst bias is the 19-bit window at bit 25 - 0.002%
-
-
-[[[ Keyset 'Window' Tests ]]]
-
-Keyset 'Window' -  32-bit key,  25-bit window - 32 tests, 33554432 keys per test
-Window at   0 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   1 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   2 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   3 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   4 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   5 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   6 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   7 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   8 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at   9 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  10 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  11 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  12 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  13 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  14 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  15 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  16 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  17 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  18 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  19 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  20 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  21 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  22 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  23 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  24 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  25 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  26 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  27 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  28 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  29 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  30 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  31 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Window at  32 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-
-
-[[[ Keyset 'Zeroes' Tests ]]]
-
-Keyset 'Zeroes' - 204800 keys
-Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          9.8, actual      9 (0.92x)
-Testing collisions (high 21-30 bits) - Worst is 30 bits: 29/39 (0.74x)
-Testing collisions (high 12-bit) - Expected     204800.0, actual 200704 (0.98x)
-Testing collisions (high  8-bit) - Expected     204800.0, actual 204544 (1.00x) (-256)
-Testing collisions (low  32-bit) - Expected          9.8, actual      5 (0.51x)
-Testing collisions (low  21-30 bits) - Worst is 27 bits: 173/312 (0.55x)
-Testing collisions (low  12-bit) - Expected     204800.0, actual 200704 (0.98x)
-Testing collisions (low   8-bit) - Expected     204800.0, actual 204544 (1.00x) (-256)
-Testing distribution - Worst bias is the 15-bit window at bit 23 - 0.330%
-
 [[[ MomentChi2 Tests ]]]
 
 Analyze hashes produced from a serie of linearly increasing numbers of 32-bit, using a step of 3 ... 
@@ -1460,12 +1463,16 @@ MomentChi2 for deriv b0 :   1.34342
 
 [[[ Prng Tests ]]]
 
-Generating 33554432 random numbers : 
+Generating 33554432 random numbers :
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 32-bit) - Expected     262144.0, actual 130902 (0.50x)
 Testing collisions (high 29-45 bits) - Worst is 45 bits: 18/31 (0.56x)
+Testing collisions (high 12-bit) - Expected   33554432.0, actual 33550336 (1.00x) (-4096)
+Testing collisions (high  8-bit) - Expected   33554432.0, actual 33554176 (1.00x) (-256)
 Testing collisions (low  32-bit) - Expected     262144.0, actual 130923 (0.50x)
 Testing collisions (low  29-45 bits) - Worst is 42 bits: 136/255 (0.53x)
+Testing collisions (low  12-bit) - Expected   33554432.0, actual 33550336 (1.00x) (-4096)
+Testing collisions (low   8-bit) - Expected   33554432.0, actual 33554176 (1.00x) (-256)
 
 
 [[[ BIC 'Bit Independence Criteria' Tests ]]]
@@ -1475,4 +1482,5 @@ Max bias 0.008568 - ( 87 :   2, 55)
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 6.382579 seconds
+Verification value is 0x00000001 - Testing took -1293.161370 seconds
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Noticed that the BEBB4185 (discohash) Sanity value was

```
Verification value 0x66CAC5F2 ....... PASS
```

Which is incorrect. I cloned the latest master and ran the benchmark and got the correct value which should be `0xBEBB4185`

This change updates `/doc/BEBB4185.txt` to reflect that benchmark and the correct Sanity Verification value.