### PR TITLE
Add mx3 hash

### DIFF
--- a/Hashes.h
+++ b/Hashes.h
@@ -22,6 +22,7 @@
 #endif
 
 #include "fasthash.h"
+#include "mx3.h"
 #include "jody_hash32.h"
 #include "jody_hash64.h"
 
@@ -359,6 +360,10 @@ inline void fasthash64_test ( const void * key, int len, uint32_t seed, void * o
   *(uint64_t*)out = fasthash64(key, (size_t) len, (uint64_t)seed);
 }
 #endif
+
+inline void mx3hash64_test ( const void * key, int len, uint32_t seed, void * out ) {
+  *(uint64_t*)out = mx3::hash((const uint8_t*)(key), (size_t) len, (uint64_t)seed);
+}
 
 // objsize 0-778: 1912
 void mum_hash_test(const void * key, int len, uint32_t seed, void * out);

--- a/main.cpp
+++ b/main.cpp
@@ -230,6 +230,7 @@ HashInfo g_hashes[] =
 # endif
 #endif
   { fasthash64_test,      64, 0xA16231A7, "fasthash64",  "fast-hash 64bit", POOR },
+  { mx3hash64_test,       64, 0x4DB51E5B, "mx3hash64",   "mx3hash 64bit", GOOD },
   { CityHash32_test,      32, 0x5C28AD62, "City32",      "Google CityHash32WithSeed (old)", POOR },
 #ifdef HAVE_INT64
   { metrohash64_test,      64, 0x6FA828C9, "metrohash64",    "MetroHash64, 64-bit", POOR },

--- a/mx3.h
+++ b/mx3.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// author: Jon Maiga, 2020-08-03, jonkagstrom.com, @jonkagstrom
+// license: CC0 license
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace mx3 {
+
+static const uint64_t C = 0xbea225f9eb34556d;
+
+inline uint64_t mix(uint64_t x) {
+	x *= C;
+	x ^= x >> 33;
+	x *= C;
+	x ^= x >> 29;
+	x *= C;
+	x ^= x >> 39;
+	return x;
+}
+
+namespace internal {
+
+inline uint64_t mix_stream(uint64_t h, uint64_t x) {
+	x *= C;
+	x ^= (x >> 57) ^ (x >> 33);
+	x *= C;
+	h += x;
+	h *= C;
+	return h;
+}
+
+}
+
+inline uint64_t hash(const uint8_t* buf, size_t len, uint64_t seed) {
+	using namespace internal;
+	const uint64_t* buf64 = reinterpret_cast<const uint64_t*>(buf);
+	const uint8_t* const tail = reinterpret_cast<const uint8_t*>(buf64 + len/8);
+
+	uint64_t h = seed ^ len;
+	while (len >= 32) {
+		len -= 32;
+		h = mix_stream(h, *buf64++);
+		h = mix_stream(h, *buf64++);
+		h = mix_stream(h, *buf64++);
+		h = mix_stream(h, *buf64++);
+	}
+	
+	while (len >= 8) {
+		len -= 8;
+		h = mix_stream(h, *buf64++);
+	}
+
+	uint64_t v = 0;
+	switch (len & 7) {
+		case 7: v |= static_cast<uint64_t>(tail[6]) << 48;
+		case 6: v |= static_cast<uint64_t>(tail[5]) << 40;
+		case 5: v |= static_cast<uint64_t>(tail[4]) << 32;
+		case 4: v |= static_cast<uint64_t>(tail[3]) << 24;
+		case 3: v |= static_cast<uint64_t>(tail[2]) << 16;
+		case 2: v |= static_cast<uint64_t>(tail[1]) << 8;
+		case 1: h = mix_stream(h, v | tail[0]);
+		default: ;
+	}
+	return mix(h);
+}
+
+}


### PR DESCRIPTION
Would it be interesting to add the [mx3](https://github.com/jonmaiga/mx3) hash function? (I am the author)

It passes all tests at what looks like good speed without machine specific instructions.

If so:
1) I added it next to fasthash64 in Hashes.h and main.cpp (I am not sure where the best place is?).
2) I wasn't sure if, and where, I should use HAVE_INT64 (I didn't).
3) I put GOOD as the quality assuming passing all tests with --extra would suffice (but I am not sure if this is the only requirement, so double check).

Is there anything else I would need to do?