### PR TITLE
New implementations of multiply shift

### DIFF
--- a/Hashes.cpp
+++ b/Hashes.cpp
@@ -755,57 +755,82 @@ void clhash_seed_init(size_t seed)
 }
 #endif
 
-// just to prove how bad academic papers really are:
+// Multiply shift from
 // Thorup "High Speed Hashing for Integers and Strings" 2018
 // https://arxiv.org/pdf/1504.06804.pdf
 // objsize: 0x1bc0-0x1d19: 345
-void multiply_shift (const void *key, int len, uint32_t seed, void *out) {
-  size_t h   = (size_t)(seed | 1);
-  size_t *dw = (size_t *)key; //word stepper
-  const size_t *const endw = &((const size_t*)key)[len/sizeof(size_t)];
-  const int bits = 8 * sizeof(size_t);
-  const size_t shift = bits - len >= 0
-    ? bits - len : len % bits;
-  // hashes x universally into len bits using the random odd seed.
-  while (dw < endw) {
-    h += (*dw++ * h) >> shift;
-  }
-  if (len & (bits-1)) {
-    uint8_t *dc = (uint8_t*)dw; //byte stepper
-    const uint8_t *const endc = &((const uint8_t*)key)[len];
-    while (dc < endc) {
-      h += (*dc++ * h) >> shift;
-    }
-  }
-  *(size_t *) out = h + (seed & 8);
+//
+const static int MULTIPLY_SHIFT_RANDOM_WORDS = 1<<15;
+static __uint128_t multiply_shift_random[MULTIPLY_SHIFT_RANDOM_WORDS];
+const static __uint128_t multiply_shift_r = ((__uint128_t)0x75f17d6b3588f843 << 64) | 0xb13dea7c9c324e51;
+void multiply_shift(const void * key, int len_bytes, uint32_t seed, void * out) {
+   const uint8_t* buf = (const uint8_t*) key;
+   const uint64_t* buf64 = reinterpret_cast<const uint64_t*>(key);
+   int len = len_bytes/8;
+
+   // The output is 64 bits, and we consider the input 64 bit as well,
+   // so our intermediate values are 128.
+   __uint128_t h = (__uint128_t)seed ^ multiply_shift_r;
+   // We mix in len_bytes in the basis, since smhasher considers two keys
+   // of different length to be different, even if all the extra bits are 0.
+   // This is needed for the AppendZero test.
+   h ^= (__uint128_t)len_bytes << 64;
+   for (int i = 0; i < len; i++)
+      h += multiply_shift_random[i & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)buf64[i];
+
+   // Get the last bytes when things are unaligned
+   uint64_t last = 0;
+   for (int i = 8*len; i < len_bytes; i++)
+      last = (last << 8) | buf[i];
+   h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)last;
+
+   *(uint64_t*)out = h >> 64;
+}
+void multiply_shift_seed_init_slow(size_t seed) {
+   srand(seed);
+   for (int i = 0; i < MULTIPLY_SHIFT_RANDOM_WORDS; i++) {
+      // We don't know how many bits we get from rand(),
+      // but it is at least 16, so we concattenate a couple.
+      for (int j = 0; j < 8; j++) {
+         multiply_shift_random[i] <<= 16;
+         multiply_shift_random[i] ^= rand();
+      }
+      // We don't need an odd multiply, when we add the seed in the beginning
+      //multiply_shift_random[i] |= 1;
+   }
+}
+void multiply_shift_seed_init(size_t seed) {
+   // The seeds we get are not random values, but just something like 1, 2 or 3.
+   // So we xor it with a random number to get something slightly more reasonable.
+   multiply_shift_random[0] = (__uint128_t)seed ^ multiply_shift_r;
+}
+void multiply_shift_init() {
+   multiply_shift_seed_init_slow(0);
 }
 
-// objsize: 0x1d20-0x1f81: 609
-void pair_multiply_shift (const void *key, int len, uint32_t seed, void *out) {
-  const uint16_t h1 = (seed & 0xffff) | 0x423d0001;
-  const uint16_t h2 = (seed >> 8)     | 0x1f380001;
-  const uint8_t b   = seed & 8;
-  size_t h = seed | 1;
-  size_t *dw = (size_t *)key; //word stepper
-  const size_t *const endw = &((const size_t*)key)[len/sizeof(size_t) - 1];
-  const int bits = 8 * sizeof(size_t);
-  const size_t shift = bits - len >= 0
-    ? bits - len : len % bits;
-  // hashes x universally into len bits using the random odd seed pair.
-  while (dw < endw) {
-    h += (*dw + h1) * (*(dw+1) + h2) + b;
-    dw++; dw++;
-  }
-  h >>= shift;
-  if (len & (bits-1)) {
-    uint8_t *dc = (uint8_t*)dw; //byte stepper
-    const uint8_t *const endc = &((const uint8_t*)key)[len-1];
-    while (dc < endc) {
-      h += (*dc + h1) * (*(dc+1) + h2) + b;
-      dc++; dc++;
-    }
-  }
-  *(size_t *) out = h;
+// Vector multiply-shift (3.4) from Thorup's notes.
+void pair_multiply_shift(const void * key, int len_bytes, uint32_t seed, void * out) {
+   const uint8_t* buf = (const uint8_t*) key;
+   const uint64_t* buf64 = reinterpret_cast<const uint64_t*>(key);
+   int len = len_bytes/8;
+
+   __uint128_t h = (__uint128_t)seed ^ multiply_shift_r;
+   h ^= (__uint128_t)len_bytes << 64;
+   for (int i = 0; i < len/2; i++)
+      h += (multiply_shift_random[2*i & MULTIPLY_SHIFT_RANDOM_WORDS-1] + buf64[2*i+1])
+         * (multiply_shift_random[2*i+1 & MULTIPLY_SHIFT_RANDOM_WORDS-1] + buf64[2*i]);
+
+   // Make sure we have the last word, if the number of words is odd
+   if (len & 1)
+      h += multiply_shift_random[len-1 & MULTIPLY_SHIFT_RANDOM_WORDS-1] * buf64[len-1];
+
+   // Get the last bytes when things are unaligned
+   uint64_t last = 0;
+   for (int i = 8*len; i < len_bytes; i++)
+      last = (last << 8) | buf[i];
+   h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * last;
+
+   *(uint64_t*)out = h >> 64;
 }
 
 //TODO MSVC

--- a/Hashes.h
+++ b/Hashes.h
@@ -465,6 +465,8 @@ void clhash_seed_init(size_t seed);
 void clhash_test (const void * key, int len, uint32_t seed, void * out);
 #endif
 
+void multiply_shift_init();
+void multiply_shift_seed_init(size_t seed);
 void multiply_shift (const void * key, int len, uint32_t seed, void * out);
 void pair_multiply_shift (const void *key, int len, uint32_t seed, void *out);
 

--- a/Hashes.h
+++ b/Hashes.h
@@ -465,10 +465,13 @@ void clhash_seed_init(size_t seed);
 void clhash_test (const void * key, int len, uint32_t seed, void * out);
 #endif
 
-void multiply_shift_init();
-void multiply_shift_seed_init(size_t seed);
-void multiply_shift (const void * key, int len, uint32_t seed, void * out);
-void pair_multiply_shift (const void *key, int len, uint32_t seed, void *out);
+
+#ifdef __SIZEOF_INT128__
+   void multiply_shift_init();
+   void multiply_shift_seed_init(size_t seed);
+   void multiply_shift (const void * key, int len, uint32_t seed, void * out);
+   void pair_multiply_shift (const void *key, int len, uint32_t seed, void *out);
+#endif
 
 void HighwayHash_init();
 // objsize 20-a12: 2546

--- a/main.cpp
+++ b/main.cpp
@@ -577,9 +577,11 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     fflush(NULL);
   } else {
     // known slow hashes (> 500), cycle/hash
-    const struct { pfHash h; double cycles; } speeds[] =
-    {{ multiply_shift,    50.50 },
+    const struct { pfHash h; double cycles; } speeds[] = {
+#ifdef __SIZEOF_INT128__
+     { multiply_shift,    50.50 },
      { pair_multiply_shift,31.71},
+#endif
      { md5_32,           670.99 },
      { md5_128,          730.30 },
      { sha1_32a,        1385.80 },
@@ -620,7 +622,7 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     printf("[[[ 'Hashmap' Speed Tests ]]]\n\n");
     fflush(NULL);
     int trials = 50;
-    if ((g_speed > 500 /*|| hash == multiply_shift || hash == pair_multiply_shift*/ )
+    if ((g_speed > 500)
          && !g_testExtra)
       trials = 5;
     bool result = true;
@@ -1259,7 +1261,6 @@ void test ( hashfunc<hashtype> hash, HashInfo* info )
     bool dumpCollisions = g_drawDiagram; // from --verbose
     int reps = 1000;
     if ((g_speed > 500.0 || info->hashbits > 128 ||
-         hash == multiply_shift || hash == pair_multiply_shift ||
          hash == o1hash_test) && !g_testExtra)
       reps = 100; // sha1: 7m, md5: 4m53
 

--- a/main.cpp
+++ b/main.cpp
@@ -93,19 +93,14 @@ HashInfo g_hashes[] =
 #ifdef HAVE_BIT32
  #define FIBONACCI_VERIF      0x09952480
  #define FNV2_VERIF           0x739801C5
- #define MULTSHIFT_VERIF      0x0
- #define PAIRMS_VERIF         0xE6ABA97D
 #else
  #define FIBONACCI_VERIF      0xFE3BD380
  #define FNV2_VERIF           0x1967C625
- #define MULTSHIFT_VERIF      0x0
- #define PAIRMS_VERIF         0xB6B5D710
 #endif
   // M. Dietzfelbinger, T. Hagerup, J. Katajainen, and M. Penttonen. A reliable randomized
   // algorithm for the closest-pair problem. J. Algorithms, 25:19–51, 1997.
-  // must be skipped for hashmaps, extremly bad! FIXME
-  { multiply_shift, __WORDSIZE,MULTSHIFT_VERIF, "multiply_shift", "Dietzfelbinger Multiply-shift on strings", POOR },
-  { pair_multiply_shift, __WORDSIZE, PAIRMS_VERIF, "pair_multiply_shift", "Pair-multiply-shift", POOR },
+  { multiply_shift,       64, 0x605FE82A, "multiply_shift", "Dietzfelbinger Multiply-shift on strings", GOOD },
+  { pair_multiply_shift,  64, 0xE2C7D023, "pair_multiply_shift", "Pair-multiply-shift", GOOD },
   { crc32,                32, 0x3719DB20, "crc32",       "CRC-32 soft", POOR },
   { md5_128,             128, 0xF263F96F, "md5-128",     "MD5", GOOD },
   { md5_32,               32, 0x634E5AEC, "md5_32a",     "MD5, low 32 bits", POOR },
@@ -425,6 +420,8 @@ void Hash_init (HashInfo* info) {
   //  md5_init();
   else if (info->hash == rmd128)
     rmd128_init(&ltc_state);
+  else if(info->hash == multiply_shift || info->hash == pair_multiply_shift)
+    multiply_shift_init();
 #if defined(__SSE4_2__) && defined(__x86_64__)
   else if(info->hash == clhash_test)
     clhash_init();
@@ -459,8 +456,10 @@ void Hash_Seed_init (pfHash hash, size_t seed) {
   //  md5_seed_init(seed);
   //if (hash == VHASH_32 || hash == VHASH_64)
   //  VHASH_seed_init(seed);
+  if(hash == multiply_shift || hash == pair_multiply_shift)
+    multiply_shift_seed_init(seed);
 #if defined(__SSE4_2__) && defined(__x86_64__)
-  if (hash == clhash_test)
+  else if (hash == clhash_test)
     clhash_seed_init(seed);
   else if (hash == umash32 ||
           hash == umash32_hi ||

--- a/main.cpp
+++ b/main.cpp
@@ -97,10 +97,12 @@ HashInfo g_hashes[] =
  #define FIBONACCI_VERIF      0xFE3BD380
  #define FNV2_VERIF           0x1967C625
 #endif
+#ifdef __SIZEOF_INT128__
   // M. Dietzfelbinger, T. Hagerup, J. Katajainen, and M. Penttonen. A reliable randomized
   // algorithm for the closest-pair problem. J. Algorithms, 25:19–51, 1997.
-  { multiply_shift,       64, 0x605FE82A, "multiply_shift", "Dietzfelbinger Multiply-shift on strings", GOOD },
-  { pair_multiply_shift,  64, 0xE2C7D023, "pair_multiply_shift", "Pair-multiply-shift", GOOD },
+  { multiply_shift,       64, 0, "multiply_shift", "Dietzfelbinger Multiply-shift on strings", GOOD },
+  { pair_multiply_shift,  64, 0, "pair_multiply_shift", "Pair-multiply-shift", GOOD },
+#endif
   { crc32,                32, 0x3719DB20, "crc32",       "CRC-32 soft", POOR },
   { md5_128,             128, 0xF263F96F, "md5-128",     "MD5", GOOD },
   { md5_32,               32, 0x634E5AEC, "md5_32a",     "MD5, low 32 bits", POOR },
@@ -420,8 +422,10 @@ void Hash_init (HashInfo* info) {
   //  md5_init();
   else if (info->hash == rmd128)
     rmd128_init(&ltc_state);
+#ifdef __SIZEOF_INT128__
   else if(info->hash == multiply_shift || info->hash == pair_multiply_shift)
     multiply_shift_init();
+#endif
 #if defined(__SSE4_2__) && defined(__x86_64__)
   else if(info->hash == clhash_test)
     clhash_init();
@@ -456,8 +460,12 @@ void Hash_Seed_init (pfHash hash, size_t seed) {
   //  md5_seed_init(seed);
   //if (hash == VHASH_32 || hash == VHASH_64)
   //  VHASH_seed_init(seed);
-  if(hash == multiply_shift || hash == pair_multiply_shift)
+  if (true)
+     ;
+#ifdef __SIZEOF_INT128__
+  else if(hash == multiply_shift || hash == pair_multiply_shift)
     multiply_shift_seed_init(seed);
+#endif
 #if defined(__SSE4_2__) && defined(__x86_64__)
   else if (hash == clhash_test)
     clhash_seed_init(seed);


### PR DESCRIPTION
I have reimplemented multiply shift to be faster and correct according to the paper.
They still don't pass all the tests, but they pass Sanity and Hashmap, which is what they were designed to do.
This is follow up on the discussion at https://github.com/rurban/smhasher/commit/fe87441408c77d9b9493128f0c6d7e454013827b .