### PR TITLE
Slightly faster handling of odd byte numbers

### DIFF
--- a/Hashes.cpp
+++ b/Hashes.cpp
@@ -780,10 +780,9 @@ void clhash_seed_init(size_t seed)
       // Now get the last bytes when things are unaligned
 
       // This method is slowest:  34.637 cycles/hash
-      /*
-      if (len_bytes & 7) {
-         uint64_t last;
-         std::copy(&last, buf+8*len, len_bytes-8*len);
+      /*if (len_bytes & 7) {
+         uint64_t last = 0;
+         memcpy(&last, buf+8*len, len_bytes-8*len);
          h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)last;
       }*/
 

--- a/Hashes.cpp
+++ b/Hashes.cpp
@@ -770,19 +770,38 @@ void clhash_seed_init(size_t seed)
 
       // The output is 64 bits, and we consider the input 64 bit as well,
       // so our intermediate values are 128.
-      __uint128_t h = (__uint128_t)seed ^ multiply_shift_r;
       // We mix in len_bytes in the basis, since smhasher considers two keys
       // of different length to be different, even if all the extra bits are 0.
       // This is needed for the AppendZero test.
-      h ^= (__uint128_t)len_bytes << 64;
+      __uint128_t h = (__uint128_t)(seed + len_bytes) * multiply_shift_r;
       for (int i = 0; i < len; i++)
          h += multiply_shift_random[i & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)buf64[i];
 
-      // Get the last bytes when things are unaligned
+      // Now get the last bytes when things are unaligned
+
+      // This method is slowest:  34.637 cycles/hash
+      /*
+      if (len_bytes & 7) {
+         uint64_t last;
+         std::copy(&last, buf+8*len, len_bytes-8*len);
+         h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)last;
+      }*/
+
+      // this naive approach is:  23.132 cycles/hash, avg
+      /*
       uint64_t last = 0;
       for (int i = 8*len; i < len_bytes; i++)
          last = (last << 8) | buf[i];
-      h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)last;
+      h += multiply_shift_random[len & multiply_shift_random_words-1] * (__uint128_t)last;
+      */
+
+      // Using a gate makes things slightly better: 21.895 cycles/hash
+      if (len_bytes & 7) {
+         uint64_t last = buf[8*len];
+         for (int i = 8*len+1; i < len_bytes; i++)
+            last = (last << 8) | buf[i];
+         h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)last;
+      }
 
       *(uint64_t*)out = h >> 64;
    }
@@ -814,8 +833,7 @@ void clhash_seed_init(size_t seed)
       const uint64_t* buf64 = reinterpret_cast<const uint64_t*>(key);
       int len = len_bytes/8;
 
-      __uint128_t h = (__uint128_t)seed ^ multiply_shift_r;
-      h ^= (__uint128_t)len_bytes << 64;
+      __uint128_t h = (__uint128_t)(seed + len_bytes) * multiply_shift_r;
       for (int i = 0; i < len/2; i++)
          h += (multiply_shift_random[2*i & MULTIPLY_SHIFT_RANDOM_WORDS-1] + buf64[2*i+1])
             * (multiply_shift_random[2*i+1 & MULTIPLY_SHIFT_RANDOM_WORDS-1] + buf64[2*i]);
@@ -825,10 +843,12 @@ void clhash_seed_init(size_t seed)
          h += multiply_shift_random[len-1 & MULTIPLY_SHIFT_RANDOM_WORDS-1] * buf64[len-1];
 
       // Get the last bytes when things are unaligned
-      uint64_t last = 0;
-      for (int i = 8*len; i < len_bytes; i++)
-         last = (last << 8) | buf[i];
-      h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * last;
+      if (len_bytes & 7) {
+         uint64_t last = buf[8*len];
+         for (int i = 8*len+1; i < len_bytes; i++)
+            last = (last << 8) | buf[i];
+         h += multiply_shift_random[len & MULTIPLY_SHIFT_RANDOM_WORDS-1] * (__uint128_t)last;
+      }
 
       *(uint64_t*)out = h >> 64;
    }


### PR DESCRIPTION
I'm having a bit of trouble making the code as fast for byte numbers not a multiple of 8, which is odd, since e.g. 23 bytes should never be slower than 24. E.g. I currently have
```
Small key speed test -   22-byte keys -    26.00 cycles/hash
Small key speed test -   23-byte keys -    27.75 cycles/hash
Small key speed test -   24-byte keys -    22.00 cycles/hash
Small key speed test -   25-byte keys -    24.00 cycles/hash
Small key speed test -   26-byte keys -    25.00 cycles/hash
```
Anyway, this patch makes it slightly better on my system at least.