### PR TITLE
SpeedTest: foil out of order execution without store forwarding bubbles

### DIFF
--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -186,13 +186,13 @@ NEVER_INLINE int64_t timehash_small ( pfHash hash, const void * key, int len, in
   const int NUM_TRIALS = 200;
   volatile unsigned long long int begin, end;
   uint32_t hash_temp[16] = {};
-  uint32_t *buf = new uint32_t[(len + 3) / 4];
+  uint32_t *buf = new uint32_t[1 + (len + 3) / 4]();
   memcpy(buf,key,len);
 
   begin = timer_start();
 
   for(int i = 0; i < NUM_TRIALS; i++) {
-    hash(buf,len,seed,hash_temp);
+    hash(buf + (hash_temp[0] & 1),len,seed,hash_temp);
     // XXX Add dependency between invocations of hash-function to prevent parallel
     // evaluation of them. However this way the invocations still would not be
     // fully serialized. Another option is to use lfence instruction (load-from-memory
@@ -201,7 +201,6 @@ NEVER_INLINE int64_t timehash_small ( pfHash hash, const void * key, int len, in
     //   __asm volatile ("lfence");
     // It's hard to say which one is the most realistic and sensible approach.
     seed += hash_temp[0];
-    buf[0] ^= hash_temp[0];
   }
 
   end = timer_end();


### PR DESCRIPTION
While we want to measure the latency of individual hash function
calls, without overlapped execution, doing so by writing to the hashed
buffer causes unrealistic performance issues:

1. forwarding small stores to larger loads does not always work well
2. only loads that overlap with the first 4 byte are slowed down by
   a store to those bytes.

Instead, simply derive the address of the hashed data from the
previous iteration's hash.  This change forces *every load* in the
current hash call to depend on the previous hash, and avoids
introducing store forwarding bubbles: we tend to hash strings or
buffers that were initialised a long time before the hash call.

Note how the forwarding pattern makes the previous speed test show a
difference in hash latency for xxh3 on 9-16 bytes, despite executing
the exact same instructions.  The new speculation barrier avoids this
issue, and instead shows a steady 15.7-16.0 cycles/hash for 9-16
bytes.

xxh3 Speed test (before):

```
Small key speed test -    1-byte keys -    20.63 cycles/hash
Small key speed test -    2-byte keys -    19.42 cycles/hash
Small key speed test -    3-byte keys -    18.43 cycles/hash
Small key speed test -    4-byte keys -    19.90 cycles/hash
Small key speed test -    5-byte keys -    26.27 cycles/hash
Small key speed test -    6-byte keys -    25.80 cycles/hash
Small key speed test -    7-byte keys -    24.90 cycles/hash
Small key speed test -    8-byte keys -    18.99 cycles/hash
Small key speed test -    9-byte keys -    29.00 cycles/hash
Small key speed test -   10-byte keys -    29.00 cycles/hash
Small key speed test -   11-byte keys -    29.00 cycles/hash
Small key speed test -   12-byte keys -    25.00 cycles/hash
Small key speed test -   13-byte keys -    25.94 cycles/hash
Small key speed test -   14-byte keys -    26.00 cycles/hash
Small key speed test -   15-byte keys -    26.32 cycles/hash
Small key speed test -   16-byte keys -    27.00 cycles/hash
```

xxh3 Speed test (after):

```
Small key speed test -    1-byte keys -    15.05 cycles/hash
Small key speed test -    2-byte keys -    15.23 cycles/hash
Small key speed test -    3-byte keys -    15.49 cycles/hash
Small key speed test -    4-byte keys -    17.11 cycles/hash
Small key speed test -    5-byte keys -    16.67 cycles/hash
Small key speed test -    6-byte keys -    16.80 cycles/hash
Small key speed test -    7-byte keys -    17.29 cycles/hash
Small key speed test -    8-byte keys -    17.62 cycles/hash
Small key speed test -    9-byte keys -    15.40 cycles/hash
Small key speed test -   10-byte keys -    15.92 cycles/hash
Small key speed test -   11-byte keys -    15.71 cycles/hash
Small key speed test -   12-byte keys -    15.84 cycles/hash
Small key speed test -   13-byte keys -    15.95 cycles/hash
Small key speed test -   14-byte keys -    15.92 cycles/hash
Small key speed test -   15-byte keys -    15.92 cycles/hash
Small key speed test -   16-byte keys -    15.93 cycles/hash
```