### PR TITLE
made Pearson B seedable

### DIFF
--- a/Hashes.h
+++ b/Hashes.h
@@ -1259,13 +1259,13 @@ void nmhash32x_test ( const void * key, int len, uint32_t seed, void * out );
 extern "C" {
 #include "pearson_hash/pearsonb.h"
 inline void pearsonb64_test ( const void * key, int len, uint32_t seed, void * out ) {
-  *(uint64_t*)out = pearsonb_hash_64 ((const uint8_t*)key, (size_t) len);
+  *(uint64_t*)out = pearsonb_hash_64 ((const uint8_t*)key, (size_t) len, (uint64_t) seed);
 }
 inline void pearsonb128_test ( const void * key, int len, uint32_t seed, void * out ) {
-  pearsonb_hash_128 ((uint8_t*)out, (const uint8_t*)key, (size_t) len);
+  pearsonb_hash_128 ((uint8_t*)out, (const uint8_t*)key, (size_t) len, (uint64_t) seed);
 }
 inline void pearsonb256_test ( const void * key, int len, uint32_t seed, void * out ) {
-  pearsonb_hash_256 ((uint8_t*)out, (const uint8_t*)key, (size_t) len);
+  pearsonb_hash_256 ((uint8_t*)out, (const uint8_t*)key, (size_t) len, (uint64_t) seed);
 }
 
 #if defined(HAVE_SSE42) && defined(__x86_64__)

--- a/main.cpp
+++ b/main.cpp
@@ -421,9 +421,9 @@ HashInfo g_hashes[] =
   { pearson256_test,     256, 0x7F8BEB21, "pearsonhash256",   "Pearson hash, 256-bit SSSE3, low 64-bit", POOR, {}},
 #endif
 #ifdef HAVE_INT64
-  { pearsonb64_test,      64, 0x715717DE, "pearsonbhash64",  "Pearson block hash, 64-bit", POOR, {}},
-  { pearsonb128_test,    128, 0x824DA7ED, "pearsonbhash128", "Pearson block hash, 128-bit, low 64-bit", POOR, {}},
-  { pearsonb256_test,    256, 0xE42B44CE, "pearsonbhash256", "Pearson block hash, 256-bit, low 64-bit", POOR, {}},
+  { pearsonb64_test,      64, 0xB6FF2DFC, "pearsonbhash64",  "Pearson block hash, 64-bit", POOR, {}},
+  { pearsonb128_test,    128, 0x6BEFE6EA, "pearsonbhash128", "Pearson block hash, 128-bit, low 64-bit", POOR, {}},
+  { pearsonb256_test,    256, 0x999B3C19, "pearsonbhash256", "Pearson block hash, 256-bit, low 64-bit", POOR, {}},
 #endif
   // FIXME: seed
 #ifdef __aarch64__

--- a/pearson_hash/pearsonb.c
+++ b/pearson_hash/pearsonb.c
@@ -47,15 +47,18 @@
     permute64(hash##part)
 
 
-void pearsonb_hash_256 (uint8_t *out, const uint8_t *in, size_t len) {
+void pearsonb_hash_256 (uint8_t *out, const uint8_t *in, size_t len, uint64_t seed) {
 
     uint64_t *current;
     current = (uint64_t*)in;
     uint64_t org_len = len;
-    uint64_t hash1 = 0;
-    uint64_t hash2 = 0;
-    uint64_t hash3 = 0;
-    uint64_t hash4 = 0;
+    uint64_t hash1 = seed;
+
+    permute64(hash1);
+
+    uint64_t hash2 = hash1;
+    uint64_t hash3 = hash1;
+    uint64_t hash4 = hash1;
 
     while (len > 7) {
         // digest words little endian first
@@ -109,13 +112,16 @@ void pearsonb_hash_256 (uint8_t *out, const uint8_t *in, size_t len) {
 }
 
 
-void pearsonb_hash_128 (uint8_t *out, const uint8_t *in, size_t len) {
+void pearsonb_hash_128 (uint8_t *out, const uint8_t *in, size_t len, uint64_t seed) {
 
     uint64_t *current;
     current = (uint64_t*)in;
     uint64_t org_len = len;
-    uint64_t hash1 = 0;
-    uint64_t hash2 = 0;
+    uint64_t hash1 = seed;
+
+    permute64(hash1);
+
+    uint64_t hash2 = hash1;
 
     while (len > 7) {
         // digest words little endian first
@@ -155,12 +161,14 @@ void pearsonb_hash_128 (uint8_t *out, const uint8_t *in, size_t len) {
 }
 
 
-uint64_t pearsonb_hash_64 (const uint8_t *in, size_t len) {
+uint64_t pearsonb_hash_64 (const uint8_t *in, size_t len, uint64_t seed) {
 
     uint64_t *current;
     current = (uint64_t*)in;
     uint64_t org_len = len;
-    uint64_t hash1 = 0;
+    uint64_t hash1 = seed;
+
+    permute64(hash1);
 
     while(len > 7) {
         // digest words little endian first
@@ -189,15 +197,15 @@ uint64_t pearsonb_hash_64 (const uint8_t *in, size_t len) {
 }
 
 
-uint32_t pearsonb_hash_32 (const uint8_t *in, size_t len) {
+uint32_t pearsonb_hash_32 (const uint8_t *in, size_t len, uint64_t seed) {
 
-    return pearsonb_hash_64(in, len);
+    return pearsonb_hash_64(in, len, seed);
 }
 
 
-uint16_t pearsonb_hash_16 (const uint8_t *in, size_t len) {
+uint16_t pearsonb_hash_16 (const uint8_t *in, size_t len, uint64_t seed) {
 
-    return pearsonb_hash_64(in, len);
+    return pearsonb_hash_64(in, len, seed);
 }
 
 

--- a/pearson_hash/pearsonb.h
+++ b/pearson_hash/pearsonb.h
@@ -4,14 +4,14 @@
 #include "portable_endian.h"
 
 
-void pearsonb_hash_256 (uint8_t *out, const uint8_t *in, size_t len);
+void pearsonb_hash_256 (uint8_t *out, const uint8_t *in, size_t len, uint64_t seed);
 
-void pearsonb_hash_128 (uint8_t *out, const uint8_t *in, size_t len);
+void pearsonb_hash_128 (uint8_t *out, const uint8_t *in, size_t len, uint64_t seed);
 
-uint64_t pearsonb_hash_64 (const uint8_t *in, size_t len);
+uint64_t pearsonb_hash_64 (const uint8_t *in, size_t len, uint64_t seed);
 
-uint32_t pearsonb_hash_32 (const uint8_t *in, size_t len);
+uint32_t pearsonb_hash_32 (const uint8_t *in, size_t len, uint64_t seed);
 
-uint16_t pearsonb_hash_16 (const uint8_t *in, size_t len);
+uint16_t pearsonb_hash_16 (const uint8_t *in, size_t len, uint64_t seed);
 
 void pearsonb_hash_init(void);


### PR DESCRIPTION
This pull request adds seeding to Pearson B hashing by using a permutation (the regular round permutation) of a given seed as start value for the hash value(s).

Having added this feature to Pearson B, it seems to pass all quality tests – especially those relying on a seed (Seed, PerlinNoise).