### PR TITLE
CRITICAL FIX: Compute bad seed testing bounds correctly for threaded mode

### DIFF
--- a/KeysetTest.h
+++ b/KeysetTest.h
@@ -139,7 +139,7 @@ void TestSecretRangeThread ( const HashInfo* info, const uint64_t hi,
   hashes.resize(4);
   result = true;
   printf("at %lx ", hi | start);
-  size_t end = start + len;
+  size_t end = (size_t)start + (size_t)len;
   for (size_t y=start; y < end; y++) {
     static hashtype zero;
     uint64_t seed = hi | y;


### PR DESCRIPTION
The last thread would test 0 seeds and always report success.

To see this, apply the following diff without this patch:

```diff
diff --git a/KeysetTest.h b/KeysetTest.h
index 538b782..c1e5ba6 100644
--- a/KeysetTest.h
+++ b/KeysetTest.h
@@ -140,7 +140,10 @@ void TestSecretRangeThread ( const HashInfo* info, const uint64_t hi,
   result = true;
   printf("at %lx ", hi | start);
   size_t end = start + len;
+  printf("Really [0x%016" PRIx64 ", 0x%016" PRIx64 "] ... \n", start, end);
+  size_t cnt = 0;
   for (size_t y=start; y < end; y++) {
+    cnt++;
     static hashtype zero;
     uint64_t seed = hi | y;
     if ((seed & UINT64_C(0x1ffffff)) == UINT64_C(0x1ffffff))
@@ -175,7 +178,7 @@  void TestSecretRangeThread ( const HashInfo* info, const uint64_t hi,
     }
   }
   fflush(NULL);
-  //printf("\n");
+  printf("Thread complete after %ld tests\n", cnt);
   return;
 }
```