### PR TITLE
CRITICAL FIX: Not all differentials can cause Diff test failures

### DIFF
--- a/DifferentialTest.h
+++ b/DifferentialTest.h
@@ -65,6 +65,8 @@ bool ProcessDifferentials ( std::vector<keytype> & diffs, int reps, bool dumpCol
 
     if(count > 1)
     {
+      result = false;
+
       if(dumpCollisions)
       {
         double pct = 100 * (double(count) / double(reps));


### PR DESCRIPTION
This is reported bug #199.

To see this bug in action, apply the following patch (without this fix!):
```diff
@@ -158,7 +158,7 @@ bool DiffTest ( pfHash hash, int diffbits, int reps, bool dumpCollisions )
          reps,testcount,expected);

   Hash_Seed_init (hash, g_seed);
-  for(int i = 0; i < reps; i++)
+  for(int i = 0; i < 0; i++)
   {
     if(i % (reps/10) == 0) printf(".");

@@ -173,6 +173,10 @@ bool DiffTest ( pfHash hash, int diffbits, int reps, bool dumpCollisions )

   bool result = true;

+  r.rand_p(&k1,sizeof(keytype));
+  diffs.push_back(k1);
+  diffs.push_back(k1);
+
   result &= ProcessDifferentials(diffs,reps,dumpCollisions);

   return result;
```