### PR TITLE
CRITICAL FIX: Single collisions with tiny expected counts should fail

### DIFF
--- a/Stats.h
+++ b/Stats.h
@@ -603,6 +603,12 @@ bool TestHashList ( std::vector<hashtype> & hashes, bool drawDiagram,
           printf(" !!!!!\n");
           return false;
         }
+      // don't allow expected 0.0+epsilon and actual 1
+      else if (expected < 0.001 && collcount == 1)
+        {
+          printf(" !!!!!\n");
+          return false;
+        }
     }
     else
     {


### PR DESCRIPTION
This fixes a serious bug in bad seed finding for 32-bit hashes, and
possibly other places. Previous to this, a single actual collision
with a very small expected collision count (<0.1) would NOT trigger a
test failure. The main BadSeed test only passes a handful of seeds to
TestHashList, so failures could be missed!!

To see this, try this patch without this fix, and run "SMHasher
--test=BadSeeds Spooky32":

```diff
diff --git a/KeysetTest.h b/KeysetTest.h
index 538b782..4668891 100644
--- a/KeysetTest.h
+++ b/KeysetTest.h
@@ -114,7 +114,7 @@ bool TestSecret ( const HashInfo* info, const uint64_t secret ) {
       else
         hashes.push_back(h);
     }
-    if (!TestHashList(hashes, false, true, false, false, false, false)) {
+    if (!TestHashList(hashes, false, true, false, false, false, true)) {
       printf(" Bad seed 0x%" PRIx64 " for len %d confirmed ", secret, len);
 #if !defined __clang__ && !defined _MSC_VER
       printf("=> hashes: ");
diff --git a/main.cpp b/main.cpp
index 1dffa1e..ce165be 100644
--- a/main.cpp
+++ b/main.cpp
@@ -653,7 +653,7 @@ HashInfo g_hashes[] =
   { xxhash256_test,       64, 0x024B7CF4, "xxhash256",   "xxhash256, 64-bit unportable", GOOD, {} },
 #endif
   { SpookyHash32_test,    32, 0x3F798BBB, "Spooky32",    "Bob Jenkins' SpookyHash, 32-bit result", GOOD,
-    {0x26bb3cda} /* !! */},
+    {0x111af082, 0x94c4f96c, 0xec24c166}},
   { SpookyHash64_test,    64, 0xA7F955F1, "Spooky64",    "Bob Jenkins' SpookyHash, 64-bit result", GOOD, {} },
   { SpookyHash128_test,  128, 0x8D263080, "Spooky128",   "Bob Jenkins' SpookyHash, 128-bit result", GOOD, {} },
   { SpookyV2_32_test,     32, 0xA48BE265, "SpookyV2_32",  "Bob Jenkins' SpookyV2, 32-bit result", GOOD, {} },
```