### PR TITLE
FIX: Make DiffDist2() test differentials without specifying --verbose

### DIFF
--- a/DifferentialTest.h
+++ b/DifferentialTest.h
@@ -297,7 +297,7 @@ bool DiffDistTest2 ( pfHash hash, bool drawDiagram )
       hashes[i] = h1 ^ h2;
     }
 
-    result &= TestHashList<hashtype>(hashes,true,true,drawDiagram);
+    result &= TestHashList<hashtype>(hashes,drawDiagram,true,true);
     printf("\n");
   }
 


### PR DESCRIPTION
In commit c6b3f5cf the parameters to TestHashList got reordered, and
this call seems to have been missed since then.