### PR TITLE
FIX: Reported elapsed time is wildly incorrect

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2271,11 +2271,11 @@ int main ( int argc, const char ** argv )
   //SetAffinity((1 << 2));
   //SelfTest();
 
-  int timeBegin = clock();
+  clock_t timeBegin = clock();
 
   testHash(hashToTest);
 
-  int timeEnd = clock();
+  clock_t timeEnd = clock();
 
   printf("\n");
   fflush(NULL);


### PR DESCRIPTION
Examples from some multi-hour test runs:
Verification value is 0x00000001 - Testing took 144.613073 seconds
Verification value is 0x00000001 - Testing took -1112.164161 seconds