### PR TITLE
PERF: Test only 32-bit seeds for hashes that don't use Hash_Seed_init()

### DIFF
--- a/KeysetTest.cpp
+++ b/KeysetTest.cpp
@@ -2,7 +2,7 @@
 
 #include "Platform.h"
 #include "Random.h"
-void Seed_init (HashInfo* info, size_t seed);
+bool Seed_init (HashInfo* info, size_t seed);
 
 #include <map>
 #include <set>

--- a/Stats.h
+++ b/Stats.h
@@ -12,8 +12,8 @@
 #include <stdio.h>     // for printf
 #include <assert.h>
 
-void Seed_init (HashInfo *info, size_t seed);
-void Hash_Seed_init (pfHash hash, size_t seed);
+bool Seed_init (HashInfo *info, size_t seed);
+bool Hash_Seed_init (pfHash hash, size_t seed);
 double calcScore ( const int * bins, const int bincount, const int ballcount );
 
 void plot ( double n );

--- a/main.cpp
+++ b/main.cpp
@@ -803,9 +803,9 @@ void Hash_init (HashInfo* info) {
 
 // optional hash seed initializers.
 // esp. for Hashmaps, whenever the seed changes, for expensive seeding.
-void Seed_init (HashInfo* info, size_t seed) {
-  Hash_Seed_init (info->hash, seed);
+bool Seed_init (HashInfo* info, size_t seed) {
   //Bad_Seed_init (info->hash, seed);
+  return Hash_Seed_init (info->hash, seed);
 }
 
 // Needed for hashed with a few bad seeds, to reject this seed and generate a new one.
@@ -866,7 +866,7 @@ void Bad_Seed_init (pfHash hash, uint32_t &seed) {
 #endif
 }
 
-void Hash_Seed_init (pfHash hash, size_t seed) {
+bool Hash_Seed_init (pfHash hash, size_t seed) {
   uint32_t seed32 = seed;
   //if (hash == md5_128 || hash == md5_32)
   //  md5_seed_init(seed);
@@ -906,6 +906,9 @@ void Hash_Seed_init (pfHash hash, size_t seed) {
   else if(hash == khashv64_test || hash == khashv32_test)
     khashv_seed_init(seed);
 #endif
+  else
+      return false;
+  return true;
 }
 
 


### PR DESCRIPTION
Because of how the hash() wrapper function is declared, seeds going
through it can only be 32-bits, no matter what happens inside of it
(e.g. casting back out to 64 bits before passing it to the hash). So,
*only* seeds going through Hash_Seed_init() can be wider than 32
bits. This patch disables invalid/redundant seed testing. This could
be reverted when and if the hash() wrapper changes.