### PR TITLE
Add Golden Ratio Hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,7 @@ add_library(
   ${BLAKE3_SRC}
   pengyhash.c
   pearson_hash/pearsonb.c
+  phihash.h
   # wyhash_condom.c
   ${ASCON_SRC}
   ${UMASH_SRC}

--- a/Hashes.cpp
+++ b/Hashes.cpp
@@ -1243,3 +1243,16 @@ void khashv32_test ( const void *key, int len, uint32_t seed, void *out) {
   *(uint32_t*)out = khashv32 (&khashv_seed, (const uint8_t*)key, (size_t)len);
 }
 #endif
+
+
+#include "phihash.h"
+
+#if defined HAVE_BIT32
+inline void phihash32_test (const void * key, int len, uint32_t seed, void * out) {
+  *(uint32_t*)out = hash_32(*(u32 *)key, (uint64_t)len);
+}
+#elif defined HAVE_INT64
+inline void phihash_test (const void * key, int len, uint32_t seed, void * out) {
+  *(uint64_t*)out = hash_64(*(u64 *)key, (uint64_t)len);
+}
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -579,6 +579,10 @@ HashInfo g_hashes[] =
   { khashv32_test,        32, KHASHV32_VERIF, "k-hashv32",      "Vectorized K-HashV, 32-bit", GOOD, {}},
   { khashv64_test,        64, KHASHV64_VERIF, "k-hashv64",      "Vectorized K-HashV, 64-bit", GOOD, {}},
 #endif
+#if defined HAVE_BIT32
+  { phihash32_test,  32, 0x0000FF00, "phihash", "Golden Ratio hash from Linux Kernel.", Good, {}},
+#elif HAVE_INT64
+  { phihash_test,  64, 0x0000FF00, "phihash", "Golden Ratio hash from Linux Kernel.", Good, {}},
 };
 
 HashInfo * findHash ( const char * name )

--- a/phihash.h
+++ b/phihash.h
@@ -1,0 +1,115 @@
+#ifndef _LINUX_HASH_H
+#define _LINUX_HASH_H
+/* Fast hashing routine for ints,  longs and pointers.
+   (C) 2002 Nadia Yvette Chambers, IBM */
+
+#include <stdint.h>
+
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#if defined __x86_64__
+#ifndef BITS_PER_LONG
+#define BITS_PER_LONG 64
+#endif
+#else
+#ifndef BITS_PER_LONG
+#define BITS_PER_LONG 32
+#endif
+#endif
+/*
+ * The "GOLDEN_RATIO_PRIME" is used in ifs/btrfs/brtfs_inode.h and
+ * fs/inode.c.  It's not actually prime any more (the previous primes
+ * were actively bad for hashing), but the name remains.
+ */
+#if BITS_PER_LONG == 32
+#define GOLDEN_RATIO_PRIME GOLDEN_RATIO_32
+#define hash_long(val, bits) hash_32(val, bits)
+#elif BITS_PER_LONG == 64
+#define hash_long(val, bits) hash_64(val, bits)
+#define GOLDEN_RATIO_PRIME GOLDEN_RATIO_64
+#else
+#error Wordsize not 32 or 64
+#endif
+
+/*
+ * This hash multiplies the input by a large odd number and takes the
+ * high bits.  Since multiplication propagates changes to the most
+ * significant end only, it is essential that the high bits of the
+ * product be used for the hash value.
+ *
+ * Chuck Lever verified the effectiveness of this technique:
+ * http://www.citi.umich.edu/techreports/reports/citi-tr-00-1.pdf
+ *
+ * Although a random odd number will do, it turns out that the golden
+ * ratio phi = (sqrt(5)-1)/2, or its negative, has particularly nice
+ * properties.  (See Knuth vol 3, section 6.4, exercise 9.)
+ *
+ * These are the negative, (1 - phi) = phi**2 = (3 - sqrt(5))/2,
+ * which is very slightly easier to multiply by and makes no
+ * difference to the hash distribution.
+ */
+#define GOLDEN_RATIO_32 0x61C88647
+#define GOLDEN_RATIO_64 0x61C8864680B583EBull
+
+#ifdef CONFIG_HAVE_ARCH_HASH
+/* This header may use the GOLDEN_RATIO_xx constants */
+#include <asm/hash.h>
+#endif
+
+/*
+ * The _generic versions exist only so lib/test_hash.c can compare
+ * the arch-optimized versions with the generic.
+ *
+ * Note that if you change these, any <asm/hash.h> that aren't updated
+ * to match need to have their HAVE_ARCH_* define values updated so the
+ * self-test will not false-positive.
+ */
+#ifndef HAVE_ARCH__HASH_32
+#define __hash_32 __hash_32_generic
+#endif
+static inline u32 __hash_32_generic(u32 val)
+{
+	return val * GOLDEN_RATIO_32;
+}
+
+static inline u32 hash_32(u32 val, unsigned int bits)
+{
+	/* High bits are more random, so use them. */
+	return __hash_32(val) >> (32 - bits);
+}
+
+#ifndef HAVE_ARCH_HASH_64
+#define hash_64 hash_64_generic
+#endif
+static __always_inline u32 hash_64_generic(u64 val, unsigned int bits)
+{
+#if BITS_PER_LONG == 64
+	/* 64x64-bit multiply is efficient on all 64-bit processors */
+	return val * GOLDEN_RATIO_64 >> (64 - bits);
+#else
+	/* Hash 64 bits using only 32x32-bit multiply. */
+	return hash_32((u32)val ^ __hash_32(val >> 32), bits);
+#endif
+}
+
+static inline u32 hash_ptr(const void *ptr, unsigned int bits)
+{
+	return hash_long((unsigned long)ptr, bits);
+}
+
+/* This really should be called fold32_ptr; it does no hashing to speak of. */
+static inline u32 hash32_ptr(const void *ptr)
+{
+	unsigned long val = (unsigned long)ptr;
+
+#if BITS_PER_LONG == 64
+	val ^= (val >> 32);
+#endif
+	return (u32)val;
+}
+
+#endif /* _LINUX_HASH_H */


### PR DESCRIPTION
I stole this hash function from the Linux kernel, I currently can't get smhasher to compile on my system, and I'm getting compile issues with my gcc version, and not hugely familiar with C++.

```

/home/daniel/dev/smhasher/halftime-hash.hpp:393:16: note: the ABI for passing parameters with 32-byte alignment has changed in GCC 4.6
  393 |   static Block MixOne(Block accum, Block input, uint64_t entropy) {
      |                ^~~~~~
In file included from /nix/store/1gf2flfqnpqbr1b4p4qz2f72y42bs56r-gcc-11.3.0/lib/gcc/x86_64-unknown-linux-gnu/11.3.0/include/immintrin.h:41,
                 from /nix/store/1gf2flfqnpqbr1b4p4qz2f72y42bs56r-gcc-11.3.0/lib/gcc/x86_64-unknown-linux-gnu/11.3.0/include/x86intrin.h:32,
                 from /home/daniel/dev/smhasher/meow_hash_x64_aesni.h:132,
                 from /home/daniel/dev/smhasher/Hashes.h:969,
                 from /home/daniel/dev/smhasher/Hashes.cpp:2:
/home/daniel/dev/smhasher/Hashes.cpp: In function ‘aesnihash(unsigned char*, unsigned long, unsigned int)’:
/nix/store/1gf2flfqnpqbr1b4p4qz2f72y42bs56r-gcc-11.3.0/lib/gcc/x86_64-unknown-linux-gnu/11.3.0/include/wmmintrin.h:61:1: error: inlining failed in call to ‘always_inline’ ‘_mm_aesenc_si128(long long __vector(2), long long __vector(2))’: target specific option mismatch
   61 | _mm_aesenc_si128 (__m128i __X, __m128i __Y)
      | ^~~~~~~~~~~~~~~~
      ```