### PR TITLE
jodyhash: update to version 6

### DIFF
--- a/jody_hash32.h
+++ b/jody_hash32.h
@@ -1,6 +1,7 @@
 /* Jody Bruchon's fast hashing function (headers)
  * See jody_hash.c for license information */
 
+
 /*
  * ****** WARNING *******
  *
@@ -10,6 +11,7 @@
  *
  * ****** WARNING *******
  */
+
 
 #ifndef JODY_HASH32_H
 #define JODY_HASH32_H
@@ -21,13 +23,57 @@ extern "C" {
 /* Required for uint64_t */
 #include <stdint.h>
 
-typedef uint32_t jodyhash32_t;
+/* Width of a jody_hash. Changing this will also require
+ * changing the width of tail masks to match. */
+#ifndef JODY_HASH32_WIDTH
+#define JODY_HASH32_WIDTH 32
+#endif
 
 /* Version increments when algorithm changes incompatibly */
-#define JODY_HASH_VERSION 5
+#define JODY_HASH32_VERSION 6
 
-extern jodyhash32_t jody_block_hash32(const jodyhash32_t *data,
-		const jodyhash32_t start_hash, const size_t count);
+/* DO NOT modify shifts/contants unless you know what you're doing. They were
+ * chosen after lots of testing. Changes will likely cause lots of hash
+ * collisions. The vectorized versions also use constants that have this value
+ * "baked in" which must be updated before using them. */
+#ifndef JODY_HASH32_SHIFT
+#define JODY_HASH32_SHIFT 14
+#endif
+
+/* The constant value's purpose is to cause each byte in the
+ * jodyhash32_t word to have a positionally dependent variation.
+ * It is injected into the calculation to prevent a string of
+ * identical bytes from easily producing an identical hash. */
+
+/* The tail mask table is used for block sizes that are
+ * indivisible by the width of a jodyhash32_t. It is ANDed with the
+ * final jodyhash32_t-sized element to zero out data in the buffer
+ * that is not part of the data to be hashed. */
+
+/* Set hash parameters based on requested hash width */
+typedef uint32_t jodyhash32_t;
+#ifndef JODY_HASH32_CONSTANT
+#define JODY_HASH32_CONSTANT 0xa682a37eU
+#endif
+static const jodyhash32_t tail32_mask[] = {
+	0x00000000,
+	0x000000ff,
+	0x0000ffff,
+	0x00ffffff,
+	0xffffffff
+};
+
+/* Double-length shift for double-rotation optimization */
+#define JH32_SHIFT2 ((JODY_HASH32_SHIFT * 2) - (((JODY_HASH32_SHIFT * 2) > JODY_HASH32_WIDTH) * JODY_HASH32_WIDTH))
+
+/* Macros for bitwise rotation */
+#define JH32_ROL(a)  (jodyhash32_t)((a << JODY_HASH32_SHIFT) | (a >> ((sizeof(jodyhash32_t) * 8) - JODY_HASH32_SHIFT)))
+#define JH32_ROR(a)  (jodyhash32_t)((a >> JODY_HASH32_SHIFT) | (a << ((sizeof(jodyhash32_t) * 8) - JODY_HASH32_SHIFT)))
+#define JH32_ROL2(a) (jodyhash32_t)(a << JH32_SHIFT2 | (a >> ((sizeof(jodyhash32_t) * 8) - JH32_SHIFT2)))
+#define JH32_ROR2(a) (jodyhash32_t)(a >> JH32_SHIFT2 | (a << ((sizeof(jodyhash32_t) * 8) - JH32_SHIFT2)))
+
+
+extern jodyhash32_t jody_block_hash32(const jodyhash32_t *data, const jodyhash32_t start_hash, const size_t count);
 
 #ifdef __cplusplus
 }

--- a/jody_hash64.c
+++ b/jody_hash64.c
@@ -5,9 +5,10 @@
  * a secure hash algorithm, but the calculation is drastically simpler
  * and faster.
  *
- * Copyright (C) 2014-2017 by Jody Bruchon <jody@jodybruchon.com>
+ * Copyright (C) 2014-2023 by Jody Bruchon <jody@jodybruchon.com>
  * Released under The MIT License
  */
+
 
 /*
  * ****** WARNING *******
@@ -19,65 +20,35 @@
  * ****** WARNING *******
  */
 
+
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "jody_hash64.h"
 
-/* Width of a jody_hash. Changing this will also require
- * changing the width of tail masks to match. */
-#define JODY_HASH_WIDTH 64
-
-/* DO NOT modify the shift unless you know what you're doing.
- * This shift was decided upon after lots of testing and
- * changing it will likely cause lots of hash collisions. */
-#ifndef JODY_HASH_SHIFT
-#define JODY_HASH_SHIFT 14
+/* Vector intrinsic multi-case handler header
+ * Shamelessly stolen from Marat Dukhan's answer on Stack Overflow:
+ * https://stackoverflow.com/a/22291538
+ */
+#if defined(_MSC_VER)
+     /* Microsoft C/C++-compatible compiler */
+     #include <intrin.h>
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+     /* GCC-compatible compiler, targeting x86/x86-64 */
+     #include <x86intrin.h>
+#elif defined(__GNUC__) && defined(__ARM_NEON__)
+     /* GCC-compatible compiler, targeting ARM with NEON */
+     #include <arm_neon.h>
+#elif defined(__GNUC__) && defined(__IWMMXT__)
+     /* GCC-compatible compiler, targeting ARM with WMMX */
+     #include <mmintrin.h>
+#elif (defined(__GNUC__) || defined(__xlC__)) && (defined(__VEC__) || defined(__ALTIVEC__))
+     /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
+     #include <altivec.h>
+#elif defined(__GNUC__) && defined(__SPE__)
+     /* GCC-compatible compiler, targeting PowerPC with SPE */
+     #include <spe.h>
 #endif
-
-/* The salt value's purpose is to cause each byte in the
- * jodyhash_t word to have a positionally dependent variation.
- * It is injected into the calculation to prevent a string of
- * identical bytes from easily producing an identical hash. */
-
-/* The tail mask table is used for block sizes that are
- * indivisible by the width of a jodyhash_t. It is ANDed with the
- * final jodyhash_t-sized element to zero out data in the buffer
- * that is not part of the data to be hashed. */
-
-/* Set hash parameters based on requested hash width */
-#if JODY_HASH_WIDTH == 64
-#define JODY_HASH_CONSTANT 0x1f3d5b79U
-static const jodyhash_t tail_mask[] = {
-	0x0000000000000000,
-	0x00000000000000ff,
-	0x000000000000ffff,
-	0x0000000000ffffff,
-	0x00000000ffffffff,
-	0x000000ffffffffff,
-	0x0000ffffffffffff,
-	0x00ffffffffffffff,
-	0xffffffffffffffff
-};
-#endif /* JODY_HASH_WIDTH == 64 */
-#if JODY_HASH_WIDTH == 32
-#define JODY_HASH_CONSTANT 0x1f3d5b79U
-static const jodyhash_t tail_mask[] = {
-	0x00000000,
-	0x000000ff,
-	0x0000ffff,
-	0x00ffffff,
-	0xffffffff,
-};
-#endif /* JODY_HASH_WIDTH == 32 */
-#if JODY_HASH_WIDTH == 16
-#define JODY_HASH_CONSTANT 0x1f5bU
-static const jodyhash_t tail_mask[] = {
-	0x0000,
-	0x00ff,
-	0xffff,
-};
-#endif /* JODY_HASH_WIDTH == 16 */
-
 
 /* Hash a block of arbitrary size; must be divisible by sizeof(jodyhash_t)
  * The first block should pass a start_hash of zero.
@@ -86,43 +57,144 @@ static const jodyhash_t tail_mask[] = {
  * of any amount of data. If data is not divisible by the size of
  * jodyhash_t, it is MANDATORY that the caller provide a data buffer
  * which is divisible by sizeof(jodyhash_t). */
-jodyhash_t jody_block_hash(const jodyhash_t *data,
-                           const jodyhash_t start_hash, const size_t count)
+extern jodyhash_t jody_block_hash(const jodyhash_t *data, const jodyhash_t start_hash, const size_t count)
 {
+	const jodyhash_t s_constant = JH_ROR2(JODY_HASH_CONSTANT);
 	jodyhash_t hash = start_hash;
-	jodyhash_t element;
-	jodyhash_t partial_salt;
-	size_t len;
+	jodyhash_t element, element2, partial_constant;
+	size_t length = 0;
+
+	union UINT128 {
+		__m128i  v128;
+		uint64_t v64[2];
+	};
+	union UINT128 vec_constant, vec_constant_ror2;
+	size_t vec_allocsize;
+	__m128i *aligned_data, *aligned_data_e;
+	__m128i v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12;
+	__m128i vec_const, vec_ror2;
+
 
 	/* Don't bother trying to hash a zero-length block */
 	if (count == 0) return hash;
 
-	len = count / sizeof(jodyhash_t);
-	for (; len > 0; len--) {
+	__builtin_cpu_init ();
+	if (__builtin_cpu_supports ("sse2")) {
+			/* Use SSE2 if possible */
+			vec_constant.v64[0]      = JODY_HASH_CONSTANT;
+			vec_constant.v64[1]      = JODY_HASH_CONSTANT;
+			vec_constant_ror2.v64[0] = JODY_HASH_CONSTANT_ROR2;
+			vec_constant_ror2.v64[1] = JODY_HASH_CONSTANT_ROR2;
+			/* Constants preload */
+			vec_const = _mm_load_si128(&vec_constant.v128);
+			vec_ror2  = _mm_load_si128(&vec_constant_ror2.v128);
+			if (count > 63) {
+				/* Only handle 64-byte sized chunks and leave the rest */
+				vec_allocsize =  count & 0xffffffffffffffc0U;
+				aligned_data_e = (__m128i *)aligned_alloc(32, vec_allocsize);
+				aligned_data  = (__m128i *)aligned_alloc(32, vec_allocsize);
+				if (!aligned_data_e || !aligned_data) goto oom;
+				memcpy(aligned_data, data, vec_allocsize);
+				length = vec_allocsize / 16; // sizeof(__m128i)
+
+				uint64_t *ep1 = (uint64_t *)(aligned_data_e);
+				uint64_t *ep2 = (uint64_t *)(aligned_data);
+				for (size_t i = 0; i < length; i += 4) {
+
+					v1  = _mm_load_si128(&aligned_data[i]);
+					v3  = _mm_load_si128(&aligned_data[i]);
+					v4  = _mm_load_si128(&aligned_data[i+1]);
+					v6  = _mm_load_si128(&aligned_data[i+1]);
+					v7  = _mm_load_si128(&aligned_data[i+2]);
+					v9  = _mm_load_si128(&aligned_data[i+2]);
+					v10 = _mm_load_si128(&aligned_data[i+3]);
+					v12 = _mm_load_si128(&aligned_data[i+3]);
+
+					/* "element2" gets RORed */
+					v1  = _mm_srli_epi64(v1, JODY_HASH_SHIFT);
+					v2  = _mm_slli_epi64(v3, (64 - JODY_HASH_SHIFT));
+					v1  = _mm_or_si128(v1, v2);
+					v1  = _mm_xor_si128(v1, vec_ror2);  // XOR against the ROR2 constant
+					v4  = _mm_srli_epi64(v4, JODY_HASH_SHIFT);  // Repeat for all vectors
+					v5  = _mm_slli_epi64(v6, (64 - JODY_HASH_SHIFT));
+					v4  = _mm_or_si128(v4, v5);
+					v4  = _mm_xor_si128(v4, vec_ror2);
+					v7  = _mm_srli_epi64(v7, JODY_HASH_SHIFT);
+					v8  = _mm_slli_epi64(v9, (64 - JODY_HASH_SHIFT));
+					v7  = _mm_or_si128(v7, v8);
+					v7  = _mm_xor_si128(v7, vec_ror2);
+					v10 = _mm_srli_epi64(v10, JODY_HASH_SHIFT);
+					v11 = _mm_slli_epi64(v12, (64 - JODY_HASH_SHIFT));
+					v10 = _mm_or_si128(v10, v11);
+					v10 = _mm_xor_si128(v10, vec_ror2);
+
+					/* Add the constant to "element" */
+					v3  = _mm_add_epi64(v3,  vec_const);
+					v6  = _mm_add_epi64(v6,  vec_const);
+					v9  = _mm_add_epi64(v9,  vec_const);
+					v12 = _mm_add_epi64(v12, vec_const);
+
+					/* Store everything */
+					_mm_store_si128(&aligned_data[i], v1);
+					_mm_store_si128(&aligned_data_e[i], v3);
+					_mm_store_si128(&aligned_data[i+1], v4);
+					_mm_store_si128(&aligned_data_e[i+1], v6);
+					_mm_store_si128(&aligned_data[i+2], v7);
+					_mm_store_si128(&aligned_data_e[i+2], v9);
+					_mm_store_si128(&aligned_data[i+3], v10);
+					_mm_store_si128(&aligned_data_e[i+3], v12);
+
+					/* Perform the rest of the hash normally */
+					for (size_t j = 0; j < 8; j++) {
+						element = *(ep1 + j);
+						element2 = *(ep2 + j);
+						hash += element;
+						hash ^= element2;
+						hash = JH_ROL2(hash);
+						hash += element;
+					}
+				ep1 += 8; ep2 += 8;
+				}
+
+				free(aligned_data_e); free(aligned_data);
+				data += vec_allocsize / sizeof(jodyhash_t);
+				length = (count - vec_allocsize) / sizeof(jodyhash_t);
+			} else {
+				length = count / sizeof(jodyhash_t);
+			}
+		}
+
+	/* Handle tails or everything */
+	for (; length > 0; length--) {
 		element = *data;
+		element2 = JH_ROR(element);
+		element2 ^= s_constant;
+		element += JODY_HASH_CONSTANT;
 		hash += element;
-		hash += JODY_HASH_CONSTANT;
-		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(jodyhash_t) * 8 - JODY_HASH_SHIFT); /* bit rotate left */
-		hash ^= element;
-		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(jodyhash_t) * 8 - JODY_HASH_SHIFT);
-		hash ^= JODY_HASH_CONSTANT;
+		hash ^= element2;
+		hash = JH_ROL2(hash);
 		hash += element;
 		data++;
 	}
 
 	/* Handle data tail (for blocks indivisible by sizeof(jodyhash_t)) */
-	len = count & (sizeof(jodyhash_t) - 1);
-	if (len) {
-		partial_salt = JODY_HASH_CONSTANT & tail_mask[len];
-		element = *data & tail_mask[len];
+	length = count & (sizeof(jodyhash_t) - 1);
+	if (length) {
+		partial_constant = JODY_HASH_CONSTANT & tail_mask[length];
+		element = *data & tail_mask[length];
+		hash += partial_constant;
 		hash += element;
-		hash += partial_salt;
-		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(jodyhash_t) * 8 - JODY_HASH_SHIFT);
+		hash = JH_ROL(hash);
 		hash ^= element;
-		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(jodyhash_t) * 8 - JODY_HASH_SHIFT);
-		hash ^= partial_salt;
+		hash = JH_ROL(hash);
+		hash ^= partial_constant;
 		hash += element;
 	}
 
 	return hash;
+#ifndef NO_SIMD
+oom:
+#endif
+	fprintf(stderr, "out of memory\n");
+	exit(EXIT_FAILURE);
 }

--- a/jody_hash64.c
+++ b/jody_hash64.c
@@ -30,6 +30,8 @@
 #if defined(_MSC_VER)
      /* Microsoft C/C++-compatible compiler */
      #include <intrin.h>
+     #define aligned_alloc(a,b) _aligned_malloc(b,a)
+     #define aligned_free(a) _aligned_free(a)
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
      /* GCC-compatible compiler, targeting x86/x86-64 */
      #include <x86intrin.h>
@@ -67,8 +69,11 @@ extern jodyhash_t jody_block_hash(const jodyhash_t *data, const jodyhash_t start
 	if (count == 0) return hash;
 
 #ifdef __SSE2__
+#if defined(__GNUC__)
 	__builtin_cpu_init ();
-	if (__builtin_cpu_supports ("sse2")) {
+	if (__builtin_cpu_supports ("sse2"))
+#endif /* __GNUC__ */
+	{
 			/* Use SSE2 if possible */
 			vec_constant.v64[0]      = JODY_HASH_CONSTANT;
 			vec_constant.v64[1]      = JODY_HASH_CONSTANT;

--- a/jody_hash64.h
+++ b/jody_hash64.h
@@ -1,6 +1,7 @@
 /* Jody Bruchon's fast hashing function (headers)
  * See jody_hash.c for license information */
 
+
 /*
  * ****** WARNING *******
  *
@@ -10,6 +11,8 @@
  *
  * ****** WARNING *******
  */
+
+
 
 #ifndef JODY_HASH_H
 #define JODY_HASH_H
@@ -23,13 +26,86 @@ extern "C" {
 
 /* Width of a jody_hash. Changing this will also require
  * changing the width of tail masks to match. */
-typedef uint64_t jodyhash_t;
+#ifndef JODY_HASH_WIDTH
+#define JODY_HASH_WIDTH 64
+#endif
 
 /* Version increments when algorithm changes incompatibly */
-#define JODY_HASH_VERSION 5
+#define JODY_HASH_VERSION 6
 
-jodyhash_t jody_block_hash(const jodyhash_t *data,
-                           const jodyhash_t start_hash, const size_t count);
+/* DO NOT modify shifts/contants unless you know what you're doing. They were
+ * chosen after lots of testing. Changes will likely cause lots of hash
+ * collisions. The vectorized versions also use constants that have this value
+ * "baked in" which must be updated before using them. */
+#ifndef JODY_HASH_SHIFT
+#define JODY_HASH_SHIFT 14
+#endif
+
+/* The constant value's purpose is to cause each byte in the
+ * jodyhash_t word to have a positionally dependent variation.
+ * It is injected into the calculation to prevent a string of
+ * identical bytes from easily producing an identical hash. */
+
+/* The tail mask table is used for block sizes that are
+ * indivisible by the width of a jodyhash_t. It is ANDed with the
+ * final jodyhash_t-sized element to zero out data in the buffer
+ * that is not part of the data to be hashed. */
+
+/* Set hash parameters based on requested hash width */
+#if JODY_HASH_WIDTH == 64
+typedef uint64_t jodyhash_t;
+#ifndef JODY_HASH_CONSTANT
+#define JODY_HASH_CONSTANT           0xf20596b93bd1a710ULL
+#define JODY_HASH_CONSTANT_ROR2      0xbd1a710f20596b93ULL
+#endif
+static const jodyhash_t tail_mask[] = {
+	0x0000000000000000,
+	0x00000000000000ff,
+	0x000000000000ffff,
+	0x0000000000ffffff,
+	0x00000000ffffffff,
+	0x000000ffffffffff,
+	0x0000ffffffffffff,
+	0x00ffffffffffffff,
+	0xffffffffffffffff
+};
+#endif /* JODY_HASH_WIDTH == 64 */
+#if JODY_HASH_WIDTH == 32
+typedef uint32_t jodyhash_t;
+#ifndef JODY_HASH_CONSTANT
+#define JODY_HASH_CONSTANT 0xa682a37eU
+#endif
+static const jodyhash_t tail_mask[] = {
+	0x00000000,
+	0x000000ff,
+	0x0000ffff,
+	0x00ffffff,
+	0xffffffff
+};
+#endif /* JODY_HASH_WIDTH == 32 */
+#if JODY_HASH_WIDTH == 16
+typedef uint16_t jodyhash_t;
+#ifndef JODY_HASH_CONSTANT
+#define JODY_HASH_CONSTANT 0x1f5bU
+#endif
+static const jodyhash_t tail_mask[] = {
+	0x0000,
+	0x00ff,
+	0xffff
+};
+#endif /* JODY_HASH_WIDTH == 16 */
+
+/* Double-length shift for double-rotation optimization */
+#define JH_SHIFT2 ((JODY_HASH_SHIFT * 2) - (((JODY_HASH_SHIFT * 2) > JODY_HASH_WIDTH) * JODY_HASH_WIDTH))
+
+/* Macros for bitwise rotation */
+#define JH_ROL(a)  (jodyhash_t)((a << JODY_HASH_SHIFT) | (a >> ((sizeof(jodyhash_t) * 8) - JODY_HASH_SHIFT)))
+#define JH_ROR(a)  (jodyhash_t)((a >> JODY_HASH_SHIFT) | (a << ((sizeof(jodyhash_t) * 8) - JODY_HASH_SHIFT)))
+#define JH_ROL2(a) (jodyhash_t)(a << JH_SHIFT2 | (a >> ((sizeof(jodyhash_t) * 8) - JH_SHIFT2)))
+#define JH_ROR2(a) (jodyhash_t)(a >> JH_SHIFT2 | (a << ((sizeof(jodyhash_t) * 8) - JH_SHIFT2)))
+
+
+extern jodyhash_t jody_block_hash(const jodyhash_t *data, const jodyhash_t start_hash, const size_t count);
 
 #ifdef __cplusplus
 }

--- a/main.cpp
+++ b/main.cpp
@@ -305,9 +305,9 @@ HashInfo g_hashes[] =
   { farsh128_test,       128, 0x82B6CBEC, "farsh128",    "FARSH 128bit", POOR, {} },
   { farsh256_test,       256, 0xFEBEA0BC, "farsh256",    "FARSH 256bit", POOR, {} },
 #endif
-  { jodyhash32_test,      32, 0xFB47D60D, "jodyhash32",  "jodyhash, 32-bit (v5)", POOR, {} },
+  { jodyhash32_test,      32, 0xA2AEFC60, "jodyhash32",  "jodyhash, 32-bit (v5)", POOR, {} },
 #ifdef HAVE_INT64
-  { jodyhash64_test,      64, 0x9F09E57F, "jodyhash64",  "jodyhash, 64-bit (v5)", POOR, {} },
+  { jodyhash64_test,      64, 0x68AA2026, "jodyhash64",  "jodyhash, 64-bit (v5)", POOR, {} },
 #endif
   { lookup3_test,         32, 0x3D83917A, "lookup3",     "Bob Jenkins' lookup3", POOR, {0x21524101} /* !! */},
 #ifdef __aarch64__


### PR DESCRIPTION
The v6 algorithm uses a better constant and several performance improvements. It now outperforms xxHash64 by about double and outperforms xxh3 by a tiny bit, or at worst is the same speed. The less favorable properties still remain but the collisions are good enough for use in non-secure ways.