### PR TITLE
optimize aesni-hash latency for small key

### DIFF
--- a/aesni-hash.h
+++ b/aesni-hash.h
@@ -14,24 +14,26 @@
 extern "C" {
 #endif
 
-static inline __m128i AESNI_Hash128(const uint8_t* msg, unsigned len, uint32_t seed = 0) {
+static __m128i AESNI_Hash128(const uint8_t* msg, unsigned len, uint32_t seed = 0) {
 	auto a = _mm_set1_epi32(seed);
 	auto b = _mm_set1_epi32(len);
 	auto m = _mm_set_epi32(0xdeadbeef, 0xffff0000, 0x01234567, 0x89abcdef);
 	auto s = _mm_set_epi8(3, 7, 11, 15, 2, 6, 10, 14, 1, 5, 9, 13, 0, 4, 8, 12);
 
+	bool greed = (((uintptr_t)msg + (len-1)) & 0xfffUL) >= 15; // do not cross page
+
 	if (len > 80) {
 		auto c = _mm_aesenc_si128(a, m);
 		auto d = _mm_aesdec_si128(b, m);
 		do {
-			a = _mm_aesenc_si128(_mm_xor_si128(a, _mm_lddqu_si128((const __m128i*)msg)), m);
-			b = _mm_aesdec_si128(_mm_xor_si128(b, _mm_lddqu_si128((const __m128i*)(msg + 16))), m);
-			c = _mm_aesenc_si128(_mm_xor_si128(c, _mm_lddqu_si128((const __m128i*)(msg + 32))), m);
-			d = _mm_aesdec_si128(_mm_xor_si128(d, _mm_lddqu_si128((const __m128i*)(msg + 48))), m);
-			a = _mm_shuffle_epi8(a, s);
-			b = _mm_shuffle_epi8(b, s);
-			c = _mm_shuffle_epi8(c, s);
-			d = _mm_shuffle_epi8(d, s);
+			a = _mm_xor_si128(a, _mm_lddqu_si128((const __m128i*)msg));
+			b = _mm_xor_si128(b, _mm_lddqu_si128((const __m128i*)(msg + 16)));
+			c = _mm_xor_si128(c, _mm_lddqu_si128((const __m128i*)(msg + 32)));
+			d = _mm_xor_si128(d, _mm_lddqu_si128((const __m128i*)(msg + 48)));
+			a = _mm_shuffle_epi8(_mm_aesenc_si128(a, m), s);
+			b = _mm_shuffle_epi8(_mm_aesdec_si128(b, m), s);
+			c = _mm_shuffle_epi8(_mm_aesenc_si128(c, m), s);
+			d = _mm_shuffle_epi8(_mm_aesdec_si128(d, m), s);
 			msg += 64;
 			len -= 64;
 		} while (len > 80);
@@ -52,6 +54,32 @@ static inline __m128i AESNI_Hash128(const uint8_t* msg, unsigned len, uint32_t s
 		mix(_mm_lddqu_si128((const __m128i*)msg));
 		msg += 16;
 		len -= 16;
+	}
+
+	if (greed) {
+#define GREEDILY_READ(n, addr) \
+        _mm_bsrli_si128(_mm_bslli_si128(_mm_lddqu_si128((const __m128i*)addr), (16-(n))), (16-(n)))
+
+		switch (len) {
+			case 15: mix(GREEDILY_READ(15,msg)); break;
+			case 14: mix(GREEDILY_READ(14,msg)); break;
+			case 13: mix(GREEDILY_READ(13,msg)); break;
+			case 12: mix(GREEDILY_READ(12,msg)); break;
+			case 11: mix(GREEDILY_READ(11,msg)); break;
+			case 10: mix(GREEDILY_READ(10,msg)); break;
+			case 9: mix(GREEDILY_READ(9,msg)); break;
+			case 8: mix((__m128i)_mm_load_sd((const double*)msg)); break;
+			case 7: mix(GREEDILY_READ(7,msg)); break;
+			case 6: mix(GREEDILY_READ(6,msg)); break;
+			case 5: mix(GREEDILY_READ(5,msg)); break;
+			case 4: mix((__m128i)_mm_load_ss((const float*)msg)); break;
+			case 3: mix(GREEDILY_READ(3,msg)); break;
+			case 2: mix(GREEDILY_READ(2,msg)); break;
+			case 1: mix(GREEDILY_READ(1,msg)); break;
+			case 0: break;
+		}
+#undef GREEDILY_READ
+		return _mm_aesenc_si128(a, b);
 	}
 
 	uint64_t x = 0;

--- a/aesni-hash.h
+++ b/aesni-hash.h
@@ -76,7 +76,10 @@ static __m128i AESNI_Hash128(const uint8_t* msg, unsigned len, uint32_t seed = 0
 			case 3: mix(GREEDILY_READ(3,msg)); break;
 			case 2: mix(GREEDILY_READ(2,msg)); break;
 			case 1: mix(GREEDILY_READ(1,msg)); break;
-			case 0: break;
+			case 0:
+			default:
+				a = _mm_xor_si128(a, m);
+				b = _mm_shuffle_epi8(b, s);
 		}
 #undef GREEDILY_READ
 		return _mm_aesenc_si128(a, b);
@@ -120,8 +123,11 @@ static __m128i AESNI_Hash128(const uint8_t* msg, unsigned len, uint32_t seed = 0
 		case 1:
 			x |= msg[0];
 			mix(_mm_set_epi64x(0, x));
-		case 0:
 			break;
+		case 0:
+		default:
+			a = _mm_xor_si128(a, m);
+			b = _mm_shuffle_epi8(b, s);
 	}
 	return _mm_aesenc_si128(a, b);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -371,8 +371,8 @@ HashInfo g_hashes[] =
   { aesnihash_test,       64, 0xA68E0D42, "aesnihash",    "majek's seeded aesnihash with aesenc, 64-bit for x64", POOR,
     {0x70736575} },
 
-  { aesni128_test,       128, 0xDBF4A092, "aesni",    "aesni 128bit", GOOD,{} },
-  { aesni64_test,         64, 0xD5E8F2D5, "aesni-low","aesni 64bit",  GOOD,{} },
+  { aesni128_test,       128, 0xF616EDFC, "aesni",    "aesni 128bit", GOOD,{} },
+  { aesni64_test,         64, 0x52ED7AD7, "aesni-low","aesni 64bit",  GOOD,{} },
 #endif
 #if defined(HAVE_SSE2) && defined(__x86_64__) && !defined(_WIN32) && !defined(_MSC_VER)
   { falkhash_test_cxx,    64, 0x2F99B071, "falkhash",    "falkhash.asm with aesenc, 64-bit for x64", POOR, {} },


### PR DESCRIPTION
A little speed-up.
Now, it may be one of the fastest hash functions on modern X86-64 machine without known flaw.