### PR TITLE
Add new XMSX Hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -716,6 +716,7 @@ add_library(
   ${ASCON_SRC}
   ${UMASH_SRC}
   ${KHASHV_SRC}
+  xmsx.c
   )
 
 add_executable(SMHasher main.cpp)

--- a/Hashes.h
+++ b/Hashes.h
@@ -8,6 +8,7 @@
 #include "MurmurHash2.h"
 #include "MurmurHash3.h"
 #include "PMurHash.h"
+#include "xmsx.h"
 
 #define XXH_INLINE_ALL
 #include "xxhash.h"
@@ -311,6 +312,7 @@ inline void MurmurHash2A_test ( const void * key, int len, uint32_t seed, void *
   *(uint32_t*)out = MurmurHash2A(key,len,seed);
 }
 
+
 #if __WORDSIZE >= 64
 inline void MurmurHash64A_test ( const void * key, int len, uint32_t seed, void * out )
 {
@@ -328,6 +330,16 @@ inline void MurmurHash64B_test ( const void * key, int len, uint32_t seed, void 
   *(uint64_t*)out = MurmurHash64B(key,len,seed);
 }
 #endif
+
+inline void xmsx32_test ( const void * key, int len, uint32_t seed, void * out )
+{
+  *(uint32_t*)out = xmsx32(key, (size_t)len, seed);
+}
+
+inline void xmsx64_test ( const void * key, int len, uint32_t seed, void * out )
+{
+  *(uint64_t*)out = xmsx64(key, (size_t)len, seed);
+}
 
 inline void jodyhash32_test( const void * key, int len, uint32_t seed, void * out ) {
   *(uint32_t*)out = jody_block_hash32((const jodyhash32_t *)key, (jodyhash32_t) seed, (size_t) len);

--- a/main.cpp
+++ b/main.cpp
@@ -106,6 +106,9 @@ HashInfo g_hashes[] =
 #define FNV2_VERIF           0x1967C625
 #endif
 
+{ xmsx32_test,          32, 0x6B54E1D4, "xmsx32", "XMSX-32", GOOD, { 0x1505929f, 0xf0a6a74a } },
+{ xmsx64_test,          64, 0x2DF7A6BD, "xmsx64", "XMSX-64", POOR, { } },
+
 #ifdef __SIZEOF_INT128__
 // M. Dietzfelbinger, T. Hagerup, J. Katajainen, and M. Penttonen. A reliable randomized
 // algorithm for the closest-pair problem. J. Algorithms, 25:19–51, 1997.

--- a/xmsx.h
+++ b/xmsx.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Dmitrii Lebed <lebed.dmitry@gmail.com>
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/*
+ * XMSX (XOR - Multiply - Shift - XOR) Hash
+ * Inspired by MUM and Murmur hashes
+ *
+ * Design inputs:
+ *   - be faster than SW CRC32 on modern 32-bit CPUs (and microcontrollers)
+ *      (supporting HW 32bx32b->64b multiplication)
+ *   - be as simple as possible (small code size)
+ *   - try to reuse the same core round function (xor-mul-shift-xor)
+ *   - provide reasonable hashing quality (pass SMHasher tests)
+ * XMSX32 passes all SMHasher tests (2 bad seeds)
+ * XMSX64 currently fails one MomentChi2 test
+ */
+
+#ifndef XMSX_H
+#define XMSX_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+uint32_t xmsx32(const void *buf, size_t len, uint32_t seed);
+uint64_t xmsx64(const void *buf, size_t len, uint32_t seed);
+
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* XMSX_H */


### PR DESCRIPTION
XMSX (XOR - Multiply - Shift - XOR) Hash
Inspired by MUM and Murmur hashes

Design inputs:
  - be faster than SW CRC32 on modern 32-bit CPUs (and microcontrollers) (supporting HW 32bx32b->64b multiplication)
  - be as simple as possible (small code size)
  - try to reuse the same core round function (xor-mul-shift-xor)
  - provide reasonable hashing quality (pass SMHasher tests)

XMSX32 passes all SMHasher tests (2 bad seeds)
XMSX64 currently fails one MomentChi2 test (might be fixed later)