### PR TITLE
Add MIPS CPU cycle counter

### DIFF
--- a/Platform.h
+++ b/Platform.h
@@ -57,6 +57,7 @@ void SetAffinity ( int cpu );
 
 #pragma intrinsic(__rdtsc)
 // Read Time Stamp Counter
+#define timer_counts_ns() (false)
 #define rdtsc()       __rdtsc()
 #define timer_start() __rdtsc()
 #define timer_end()   __rdtsc()
@@ -251,6 +252,11 @@ __inline__ uint64_t timer_end()
 #endif
 }
 
+__inline__ bool timer_counts_ns ( void )
+{
+  const double ratio = double(timer_start()) / timeofday();
+  return (0.999 < ratio && ratio < 1.001);
+}
 
 #include <strings.h>
 #define _stricmp strcasecmp

--- a/Platform.h
+++ b/Platform.h
@@ -124,9 +124,21 @@ inline uint64_t rotr64 ( uint64_t x, int8_t r )
 
 __inline__ uint64_t timeofday()
 {
+#if defined(CLOCK_MONOTONIC_RAW) || defined(CLOCK_MONOTONIC)
+# if defined(CLOCK_MONOTONIC_RAW)
+  // CLOCK_MONOTONIC_RAW access is measurably faster on some platforms.
+  const clockid_t clock = CLOCK_MONOTONIC_RAW;
+# else
+  const clockid_t clock = CLOCK_MONOTONIC;
+# endif
+  struct timespec ts;
+  clock_gettime(clock, &ts);
+  return int64_t(ts.tv_sec) * 1000000000 + ts.tv_nsec;
+#else
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  return (int64_t)((tv.tv_sec) * 1000000 + tv.tv_usec);
+  return int64_t(tv.tv_sec) * 1000000000 + tv.tv_usec * 1000;
+#endif
 }
 
 #if defined(__mips16) && !defined(__mips16e2) && (defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS32R3) || defined(_MIPS_ARCH_MIPS32R5) || defined(_MIPS_ARCH_MIPS32R6))

--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -273,6 +273,11 @@ void BulkSpeedTest ( pfHash hash, uint32_t seed )
   const int trials = 2999;
   const int blocksize = 256 * 1024;
 
+  if (timer_counts_ns())
+    printf("WARNING: no cycle counter, cycle == 1ns\n");
+  if (timer_start() == timer_end())
+    printf("WARNING: timer resolution is low\n");
+
   printf("Bulk speed test - %d-byte keys\n",blocksize);
   double sumbpc = 0.0;
 


### PR DESCRIPTION
SMhasher is quite handy to benchmark hashes while cross-compiling for other platforms, so I'm adding MIPS cycle counter to have estimates based on number of cycles for my OpenWRT routers.