### PR TITLE
Fix pearsonbhash{64,128,256}

### DIFF
--- a/Hashes.h
+++ b/Hashes.h
@@ -1321,7 +1321,8 @@ extern "C" {
 #include "pearson_hash/pearsonb.h"
 // objsize: 417b50-417dfb = 683
 inline void pearsonb64_test ( const void * key, int len, uint32_t seed, void * out ) {
-  *(uint64_t*)out = pearsonb_hash_64 ((const uint8_t*)key, (size_t) len, (uint64_t) seed);
+  // pearsonb_hash_64(): caller is responsible for storing it the big endian way to memory
+  *(uint64_t*)out = htobe64(pearsonb_hash_64 ((const uint8_t*)key, (size_t) len, (uint64_t) seed));
 }
 // objsize: 41a1f0-41a65e: 1134
 inline void pearsonb128_test ( const void * key, int len, uint32_t seed, void * out ) {

--- a/main.cpp
+++ b/main.cpp
@@ -292,7 +292,7 @@ HashInfo g_hashes[] =
 { pearson256_test,     256, 0x7F8BEB21, "pearsonhash256",   "Pearson hash, 256-bit SSSE3, low 64-bit", POOR, {}},
 #endif
 #ifdef HAVE_INT64
-{ pearsonb64_test,      64, 0xB6FF2DFC, "pearsonbhash64",  "Pearson block hash, 64-bit", GOOD, {}},
+{ pearsonb64_test,      64, 0x14C3D184, "pearsonbhash64",  "Pearson block hash, 64-bit", GOOD, {}},
 { pearsonb128_test,    128, 0x6BEFE6EA, "pearsonbhash128", "Pearson block hash, 128-bit, low 64-bit", GOOD, {}},
 { pearsonb256_test,    256, 0x999B3C19, "pearsonbhash256", "Pearson block hash, 256-bit, low 64-bit", GOOD, {}},
 #endif

--- a/pearson_hash/portable_endian.h
+++ b/pearson_hash/portable_endian.h
@@ -121,9 +121,7 @@
 
 #elif defined(__WINDOWS__)
 
-#   ifdef __MINGW32__
-#     include <stdlib.h>
-#   endif
+#   include <stdlib.h>
 
 #   if BYTE_ORDER == LITTLE_ENDIAN
 


### PR DESCRIPTION
- pearsonbhash128 and pearsonbhash256 were broken on Windows due to byteswap result being casted to int: `D:\a\smhasher\smhasher\pearson_hash\pearsonb.c(105,10): warning C4013: '_byteswap_uint64' undefined; assuming extern returning int [D:\a\smhasher\smhasher\SMHasherSupport.vcxproj]`

- pearsonbhash64 was broken on big-endian machine