### PR TITLE
Report CPU frequency as measured by rdtsc() instead of 3 GHz

### DIFF
--- a/Platform.cpp
+++ b/Platform.cpp
@@ -1,6 +1,7 @@
 #include "Platform.h"
-
+#include <memory>
 #include <stdio.h>
+#include <math.h> // for lrint
 #include <assert.h>
 
 long getenvlong(const char *name, long minval, long defval, long maxval)
@@ -16,6 +17,47 @@ long getenvlong(const char *name, long minval, long defval, long maxval)
   if (l < minval) l = minval;
   if (l > maxval) l = maxval;
   return l;
+}
+
+struct StampedRdtsc
+{
+  const uint64_t ticks, ns;
+
+  StampedRdtsc() : ticks(timer_start()), ns(timeofday()) { }
+
+  bool GoodDelta(const StampedRdtsc& t) const {
+    constexpr uint64_t ms20 = 20*1000*1000; // 20ms, two ticks of HZ=100
+    constexpr uint64_t mln2 = 2*1000*1000; // 20ms @ 100 MHz = 2M ticks
+    const uint64_t dtick = timer_sub(ticks, t.ticks);
+    return mln2 <= dtick && dtick != timer_inf && ms20 <= (ns - t.ns);
+  }
+
+  unsigned int FreqMHzSince(const StampedRdtsc& t) const {
+    return lrint(double(timer_sub(ticks, t.ticks)) / (ns - t.ns) * 1e9 / 1e6);
+  }
+};
+
+static unsigned int CpuFreqMHz;
+static std::unique_ptr<StampedRdtsc> BaseTS;
+
+void SampleCpuFreq ( void )
+{
+  if (!BaseTS) {
+    if (CpuFreqMHz)
+      return;
+    else
+      BaseTS.reset(new StampedRdtsc());
+  }
+  StampedRdtsc now;
+  if (now.GoodDelta(*BaseTS))
+    CpuFreqMHz = now.FreqMHzSince(*BaseTS);
+}
+
+unsigned int GetCpuFreqMHz( void )
+{
+  if (BaseTS)
+    BaseTS.reset();
+  return CpuFreqMHz;
 }
 
 #if defined(_WIN32)
@@ -34,6 +76,18 @@ void SetThreadAffinity ( std::thread &t, int cpu )
     SetThreadIdealProcessor((HANDLE)t.native_handle(), (DWORD)cpu);
 }
 #endif
+
+uint64_t timeofday(void)
+{
+  // GetTickCount               ~ Windows 2000+
+  // GetTickCount64             ~ Vista+, Server 2008+
+  // QueryUnbiasedInterruptTime ~ Windows 7+, Server 2008 R2
+  // see https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
+  unsigned long long ns100;
+  if (QueryUnbiasedInterruptTime(&ns100))
+    return ns100 * 100u;
+  return GetTickCount64() * 1000000U;
+}
 
 #else
 

--- a/Platform.h
+++ b/Platform.h
@@ -21,6 +21,8 @@ void SetThreadAffinity ( std::thread &t, int cpu );
 # endif
 #endif
 void SetAffinity ( int cpu );
+void SampleCpuFreq(void);
+unsigned int GetCpuFreqMHz();
 long getenvlong(const char *name, long minval, long defval, long maxval);
 
 // That's not UINT64_MAX as it's converted to int64_t sometimes.
@@ -84,6 +86,7 @@ static inline uint64_t timer_sub(uint64_t a, uint64_t b)
 #pragma intrinsic(__rdtsc)
 // Read Time Stamp Counter
 #define timer_counts_ns() (false)
+uint64_t timeofday(void);
 #define rdtsc()       __rdtsc()
 #define timer_start() __rdtsc()
 #define timer_end()   __rdtsc()


### PR DESCRIPTION
It makes timer accounting issues like #241 more visible.

The overall logic is to sample (wall-clock-ns, cycle-counter) pairs and take the longest possible valid interval out of 2,999 SpeedTest() calls during `--test=SpeedBulk`.

The code has to provide reasonable MHz estimates accounting for:
- ultra-fast functions like `donothing32`
- something slower like `sha3-256`
- overflowing 32-bit cycle counter on MIPS
- the model assumes stable frequency, so it's "frozen" on the very first read call to `GetCpuFreqMHz()`

That's why the code samples the pairs on every SpeedTest() call and not just twice in some "good" places.