### PR TITLE
Tachyon Hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,19 @@ if(SSE42_FOUND AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
   # endif()
 endif()
 
+# --- Tachyon ---
+# Runtime CPUID dispatch: AVX-512+VAES -> AES-NI -> portable
+set(TACHYON_SRC
+    tachyon/tachyon_dispatcher.c
+    tachyon/tachyon_portable.c
+    tachyon/tachyon_aesni.c
+    tachyon/tachyon_avx512.c
+)
+set_source_files_properties(tachyon/tachyon_avx512.c
+    PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mvaes -mvpclmulqdq -maes -msse4.1 -mpclmul")
+set_source_files_properties(tachyon/tachyon_aesni.c
+    PROPERTIES COMPILE_FLAGS "-maes -msse4.1 -mpclmul")
+
 set(BLAKE3_SRC blake3/blake3.c blake3/blake3_dispatch.c
                blake3/blake3_portable.c)
 if(SSE42_FOUND)
@@ -741,6 +754,7 @@ add_library(
   vmac.cpp
   rijndael-alg-fst.c
   ${BLAKE3_SRC}
+  ${TACHYON_SRC}
   pengyhash.c
   pearson_hash/pearsonb.c
   edonr.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,13 +595,18 @@ endif()
 set(TACHYON_SRC
     tachyon/tachyon_dispatcher.c
     tachyon/tachyon_portable.c
-    tachyon/tachyon_aesni.c
-    tachyon/tachyon_avx512.c
 )
-set_source_files_properties(tachyon/tachyon_avx512.c
-    PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mvaes -mvpclmulqdq -maes -msse4.1 -mpclmul")
-set_source_files_properties(tachyon/tachyon_aesni.c
-    PROPERTIES COMPILE_FLAGS "-maes -msse4.1 -mpclmul")
+if(AES_FOUND AND (PROCESSOR_FAMILY STREQUAL "Intel"))
+  list(APPEND TACHYON_SRC
+      tachyon/tachyon_aesni.c
+      tachyon/tachyon_avx512.c
+  )
+  set_source_files_properties(tachyon/tachyon_avx512.c
+      PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mvaes -mvpclmulqdq -maes -msse4.1 -mpclmul")
+  set_source_files_properties(tachyon/tachyon_aesni.c
+      PROPERTIES COMPILE_FLAGS "-maes -msse4.1 -mpclmul")
+endif()
+
 
 set(BLAKE3_SRC blake3/blake3.c blake3/blake3_dispatch.c
                blake3/blake3_portable.c)

--- a/Hashes.h
+++ b/Hashes.h
@@ -1367,6 +1367,12 @@ extern "C" {
   // objsize: c300 - dc5a: 6490
   void asconhashv12_256 ( const void * key, int len, uint32_t seed, void * out );
 }
+#include "tachyon/tachyon.h"
+// objsize: CPUID-dispatched: AVX-512+VAES -> AES-NI -> portable
+inline void Tachyon_Hash ( const void * key, int len, uint32_t seed, void * out ) {
+  tachyon_hash_seeded((const uint8_t*)key, (size_t)len, (uint64_t)seed, (uint8_t*)out);
+}
+
 
 extern const char * const nmhash32_desc;
 extern const char * const nmhash32x_desc;

--- a/main.cpp
+++ b/main.cpp
@@ -160,6 +160,7 @@ HashInfo g_hashes[] =
 #define BL3_VF 0x50E4CD91
 #endif
 { blake3c_test,        256, BL3_VF, "blake3_c",   "BLAKE3 c",   GOOD, {0x6a09e667} },
+{ Tachyon_Hash, 256, 0xE9BBF229, "Tachyon", "Tachyon 256-bit C", GOOD, {} },
 #if defined(HAVE_BLAKE3)
 { blake3_test,         256, 0x0, "blake3",       "BLAKE3 Rust", GOOD, {} },
 { blake3_64,            64, 0x0, "blake3_64",    "BLAKE3 Rust, low 64 bits", GOOD, {} },

--- a/tachyon/README.md
+++ b/tachyon/README.md
@@ -1,0 +1,44 @@
+# Tachyon Hash — C Reference Implementation
+
+A C99 reference implementation of the Tachyon hash algorithm.
+
+> **Note:** Tachyon is designed for AVX-512 (VAES + VPCLMULQDQ) and AES-NI.
+> The short-input path uses AES-NI even when AVX-512 is available.
+> The portable backend exists for correctness verification and
+> cross-platform compatibility, but is not the intended performance target.
+
+For algorithm specification, architecture decisions, and security notes see the
+[main repository](https://github.com/byt3forg3/Tachyon).
+
+## Output
+
+| Property          | Value                                    |
+|---                |---                                       |
+| Digest size       | 256 bit (32 bytes)                       |
+| Internal state    | 4096 bit (≥ 64 B input), 512 bit (< 64 B)|
+| Block size        | 512 bytes                                |
+
+## Files
+
+| File                     | Purpose                                                        |
+|---                       |---                                                             |
+| `tachyon.h`              | Public API (one-shot + streaming)                              |
+| `tachyon_impl.h`         | Internal constants, macros, and kernel prototypes              |
+| `tachyon_dispatcher.c`   | CPUID runtime dispatch, Merkle tree engine, public API wrappers|
+| `tachyon_portable.c`     | Pure C fallback kernel (software AES + CLMUL)                  |
+| `tachyon_aesni.c`        | AES-NI + PCLMUL kernel (SSE4.1)                                |
+| `tachyon_avx512.c`       | AVX-512 + VAES + VPCLMULQDQ kernel                             |
+
+## Backend Selection
+
+Three backends are selected automatically at runtime via CPUID:
+
+1. **AVX-512** — requires AVX-512F, AVX-512BW, VAES, VPCLMULQDQ + OS support (XCR0)
+2. **AES-NI** — requires AES-NI, SSE4.1, PCLMUL
+3. **Portable** — pure C, runs on any platform (ARM, RISC-V, etc.)
+
+## License
+
+Copyright (c) byt3forg3 — 260008633+byt3forg3@users.noreply.github.com
+
+Licensed under the MIT or Apache 2.0 License.

--- a/tachyon/tachyon.h
+++ b/tachyon/tachyon.h
@@ -1,0 +1,71 @@
+// Tachyon
+// Copyright (c) byt3forg3
+// Licensed under the MIT or Apache 2.0 License
+// -------------------------------------------------------------------------
+
+#ifndef TACHYON_H
+#define TACHYON_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// DOMAIN CONSTANTS
+// =============================================================================
+
+#define TACHYON_DOMAIN_GENERIC           0
+#define TACHYON_DOMAIN_FILE_CHECKSUM     1
+#define TACHYON_DOMAIN_KEY_DERIVATION    2
+#define TACHYON_DOMAIN_MESSAGE_AUTH      3
+#define TACHYON_DOMAIN_DATABASE_INDEX    4
+#define TACHYON_DOMAIN_CONTENT_ADDRESSED 5
+
+#define TACHYON_SUCCESS       0
+#define TACHYON_ERROR_NULL_PTR (-1)  /* null required pointer */
+#define TACHYON_ERROR_STATE    (-2)  /* panic / unsupported CPU */
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+typedef struct tachyon_state_t tachyon_state_t;
+
+// =============================================================================
+// ONE-SHOT API
+// =============================================================================
+
+int tachyon_hash(const uint8_t *input, size_t len, uint8_t *out /*[32]*/);
+int tachyon_hash_seeded(const uint8_t *input, size_t len, uint64_t seed, uint8_t *out /*[32]*/);
+int tachyon_hash_full(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed,
+                      const uint8_t *key /*[32] or NULL*/, uint8_t *out /*[32]*/);
+int tachyon_hash_with_domain(const uint8_t *input, size_t len, uint64_t domain, uint8_t *out /*[32]*/);
+int tachyon_verify(const uint8_t *input, size_t len, const uint8_t *hash /*[32]*/);
+int tachyon_hash_keyed(const uint8_t *input, size_t len, const uint8_t *key /*[32]*/, uint8_t *out /*[32]*/);
+int tachyon_verify_mac(const uint8_t *input, size_t len, const uint8_t *key /*[32]*/, const uint8_t *mac /*[32]*/);
+int tachyon_derive_key(const char *context, size_t context_len,
+                       const uint8_t *material /*[32]*/, uint8_t *out /*[32]*/);
+/* Returns a static, null-terminated string — do NOT free. */
+const char* tachyon_get_backend_name(void);
+
+// =============================================================================
+// STREAMING API
+// =============================================================================
+
+/* Returns NULL on unsupported CPU. Caller must free with tachyon_hasher_free (or tachyon_hasher_finalize). */
+tachyon_state_t* tachyon_hasher_new(void);
+tachyon_state_t* tachyon_hasher_new_with_domain(uint64_t domain);
+tachyon_state_t* tachyon_hasher_new_seeded(uint64_t seed);
+tachyon_state_t* tachyon_hasher_new_full(uint64_t domain, uint64_t seed, const uint8_t *key /*[32] or NULL*/);
+void tachyon_hasher_update(tachyon_state_t *state, const uint8_t *data, size_t len);
+void tachyon_hasher_finalize(tachyon_state_t *state, uint8_t *out /*[32]*/); /* frees state */
+void tachyon_hasher_free(tachyon_state_t *state);                             /* frees without output */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif 

--- a/tachyon/tachyon_aesni.c
+++ b/tachyon/tachyon_aesni.c
@@ -1,0 +1,591 @@
+// Tachyon 
+// Copyright (c) byt3forg3
+// Licensed under the MIT or Apache 2.0 License
+// -------------------------------------------------------------------------
+
+#include <stdint.h>
+#include <string.h>
+#include "tachyon_impl.h"
+
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+
+#include <wmmintrin.h>
+#include <emmintrin.h>
+#include <smmintrin.h>
+// =============================================================================
+// AES-NI KERNEL
+// =============================================================================
+
+#if defined(__GNUC__) || defined(__clang__)
+  #define TARGET_AESNI __attribute__((target("aes,sse4.1,pclmul")))
+#else
+  #define TARGET_AESNI
+#endif
+
+typedef struct {
+    __m128i acc[32];
+    uint64_t block_count;
+} tachyon_aesni_state_t;
+
+TARGET_AESNI void tachyon_aesni_init(tachyon_aesni_state_t *state, const uint8_t *key, uint64_t seed);
+
+static inline __m128i init_reg(uint64_t base) {
+    return _mm_set_epi64x(base + 1, base);
+}
+
+static inline void rotate_lanes(__m128i *acc, int base) {
+    __m128i tmp = acc[base];
+    acc[base] = acc[base + 1];
+    acc[base + 1] = acc[base + 2];
+    acc[base + 2] = acc[base + 3];
+    acc[base + 3] = tmp;
+}
+
+// =============================================================================
+// COMPRESSION HELPERS
+// =============================================================================
+
+#define AES_MIX(acc, data, rk, lo, blk) \
+    _mm_aesenc_si128(acc, _mm_add_epi64(data, _mm_add_epi64(rk, _mm_add_epi64(lo, blk))))
+
+TARGET_AESNI
+static void aesni_compress_phase1_roundrobin(tachyon_aesni_state_t *state, __m128i d[NUM_LANES][LANE_STRIDE],
+                                             const __m128i rk_base[10], const __m128i lo_all[32], __m128i blk) {
+    for (int r = 0; r < 5; r++) {
+        __m128i rk = rk_base[r];
+        
+        for (int i = 0; i < 32; i++) {
+            state->acc[i] = AES_MIX(state->acc[i], d[i / 4][i % 4], rk, lo_all[i], blk);
+        }
+        
+        for (int i = 0; i < NUM_LANES; i++) {
+            int src = (i + 3) % NUM_LANES;
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                d[i][j] = _mm_xor_si128(d[i][j], state->acc[ACC_INDEX(src, j)]);
+            }
+        }
+        
+        __m128i old[32]; 
+        memcpy(old, state->acc, BLOCK_SIZE);
+        
+        for (int i = 0; i < NUM_LANES; i++) {
+            memcpy(&state->acc[ACC_INDEX(i, 0)], &old[ACC_INDEX((i + 1) % NUM_LANES, 0)], LANE_STRIDE * VEC_SIZE);
+        }
+    }
+}
+
+TARGET_AESNI
+static void aesni_compress_midblock_mixing(tachyon_aesni_state_t *state) {
+    __m128i old_m[32]; 
+    memcpy(old_m, state->acc, BLOCK_SIZE);
+    
+    for (int i = 0; i < NUM_LANES; i++) {
+        for (int j = 0; j < 4; j++) {
+            state->acc[ACC_INDEX(i, j)] = old_m[ACC_INDEX(i, (j + 1) % 4)];
+        }
+    }
+
+    /* Cross-Accumulator Diffusion Stage 1 */
+    for (int l = 0; l < 4; l++) {
+        for (int i = 0; i < 4; i++) {
+            __m128i t_lo = state->acc[ACC_INDEX(i, l)];
+            __m128i t_hi = state->acc[ACC_INDEX(i + 4, l)];
+            
+            state->acc[ACC_INDEX(i, l)]     = _mm_xor_si128(t_lo, t_hi);
+            state->acc[ACC_INDEX(i + 4, l)] = _mm_add_epi64(t_hi, t_lo);
+        }
+    }
+
+    /* Cross-Accumulator Diffusion Stage 2 */
+    for (int l = 0; l < 4; l++) {
+        __m128i a0 = state->acc[ACC_INDEX(0, l)], a2 = state->acc[ACC_INDEX(2, l)];
+        state->acc[ACC_INDEX(0, l)] = _mm_xor_si128(a0, a2); 
+        state->acc[ACC_INDEX(2, l)] = _mm_add_epi64(a2, a0);
+        
+        __m128i a1 = state->acc[ACC_INDEX(1, l)], a3 = state->acc[ACC_INDEX(3, l)];
+        state->acc[ACC_INDEX(1, l)] = _mm_xor_si128(a1, a3); 
+        state->acc[ACC_INDEX(3, l)] = _mm_add_epi64(a3, a1);
+        
+        __m128i a4 = state->acc[ACC_INDEX(4, l)], a6 = state->acc[ACC_INDEX(6, l)];
+        state->acc[ACC_INDEX(4, l)] = _mm_xor_si128(a4, a6); 
+        state->acc[ACC_INDEX(6, l)] = _mm_add_epi64(a6, a4);
+        
+        __m128i a5 = state->acc[ACC_INDEX(5, l)], a7 = state->acc[ACC_INDEX(7, l)];
+        state->acc[ACC_INDEX(5, l)] = _mm_xor_si128(a5, a7); 
+        state->acc[ACC_INDEX(7, l)] = _mm_add_epi64(a7, a5);
+    }
+}
+
+TARGET_AESNI
+static void aesni_compress_phase2_and_feedforward(tachyon_aesni_state_t *state, __m128i d[NUM_LANES][LANE_STRIDE],
+                                                  const __m128i rk_base[10], const __m128i lo_all[32], 
+                                                  __m128i blk, const __m128i saves[32]) {
+    for (int r = 5; r < 10; r++) {
+        __m128i rk = rk_base[r];
+        
+        for (int i = 0; i < 32; i++) {
+            state->acc[i] = AES_MIX(state->acc[i], d[((i / 4) + 4) % 8][i % 4], rk, lo_all[i], blk);
+        }
+        
+        for (int i = 0; i < NUM_LANES; i++) {
+            int src = (i + 3) % NUM_LANES;
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                d[i][j] = _mm_xor_si128(d[i][j], state->acc[ACC_INDEX(src, j)]);
+            }
+        }
+        
+        __m128i old[32]; 
+        memcpy(old, state->acc, BLOCK_SIZE);
+        for (int i = 0; i < NUM_LANES; i++) {
+            memcpy(&state->acc[ACC_INDEX(i, 0)], &old[ACC_INDEX((i + 1) % NUM_LANES, 0)], LANE_STRIDE * VEC_SIZE);
+        }
+    }
+
+    /* Davies-Meyer Feed-Forward */
+    __m128i old_f[32]; 
+    memcpy(old_f, state->acc, BLOCK_SIZE);
+    
+    for (int i = 0; i < NUM_LANES; i++) {
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            state->acc[ACC_INDEX(i, j)] = old_f[ACC_INDEX(i, (j + 1) % LANE_STRIDE)];
+        }
+    }
+    
+    for (int i = 0; i < 32; i++) {
+        state->acc[i] = _mm_xor_si128(state->acc[i], saves[i]);
+    }
+}
+
+// =============================================================================
+// FINALIZATION HELPERS
+// =============================================================================
+
+TARGET_AESNI
+static size_t aesni_finalize_remainder_chunks(tachyon_aesni_state_t *state, const uint8_t *remainder, size_t rem_len,
+                                              __m128i wk, const __m128i rk_chain[10]) {
+    size_t chunk_idx = 0;
+    while ((chunk_idx + 1) * REMAINDER_CHUNK_SIZE <= rem_len) {
+        const uint8_t *ptr = remainder + chunk_idx * REMAINDER_CHUNK_SIZE;
+        __m128i d_rem[LANE_STRIDE];
+        
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            d_rem[j] = _mm_aesenc_si128(_mm_loadu_si128((__m128i*)(ptr + j * VEC_SIZE)), wk);
+        }
+        
+        int base = chunk_idx * LANE_STRIDE;
+        __m128i saves[LANE_STRIDE]; 
+        memcpy(saves, &state->acc[base], REMAINDER_CHUNK_SIZE);
+        
+        for (int r = 0; r < 10; r++) {
+            __m128i rk = rk_chain[r];
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                __m128i lo = _mm_set1_epi64x(LANE_OFFSETS[base + j]);
+                state->acc[base + j] = _mm_aesenc_si128(state->acc[base + j], _mm_add_epi64(d_rem[j], _mm_add_epi64(rk, lo)));
+            }
+            
+            __m128i t0 = state->acc[base + 0];
+            __m128i t1 = state->acc[base + 1];
+            __m128i t2 = state->acc[base + 2];
+            __m128i t3 = state->acc[base + 3];
+            
+            d_rem[0] = _mm_xor_si128(d_rem[0], t1);
+            d_rem[1] = _mm_xor_si128(d_rem[1], t2);
+            d_rem[2] = _mm_xor_si128(d_rem[2], t3);
+            d_rem[3] = _mm_xor_si128(d_rem[3], t0);
+            
+            rotate_lanes(state->acc, base);
+        }
+        
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            state->acc[base + j] = _mm_xor_si128(state->acc[base + j], saves[j]);
+        }
+        
+        chunk_idx++;
+    }
+    
+    return chunk_idx * REMAINDER_CHUNK_SIZE;
+}
+
+TARGET_AESNI
+static void aesni_finalize_tree_merge(tachyon_aesni_state_t *state) {
+    __m128i mrk0 = _mm_set1_epi64x(C5);
+    __m128i mrk1 = _mm_set1_epi64x(C6);
+    __m128i mrk2 = _mm_set1_epi64x(C7);
+    
+    // Level 0: 32 -> 16
+    for (int i = 0; i < 16; i++) {
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_xor_si128(state->acc[i + 16], mrk0));
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_xor_si128(state->acc[i], mrk0));
+    }
+    
+    // Level 1: 16 -> 8
+    for (int i = 0; i < 8; i++) {
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_xor_si128(state->acc[i + 8], mrk1));
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_xor_si128(state->acc[i], mrk1));
+    }
+    
+    // Level 2: 8 -> 4
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_xor_si128(state->acc[i + LANE_STRIDE], mrk2));
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_xor_si128(state->acc[i], mrk2));
+    }
+}
+
+TARGET_AESNI
+static void aesni_finalize_clmul_hardening(tachyon_aesni_state_t *state) {
+    __m128i clmul_k = _mm_set_epi64x(CLMUL_CONSTANT2, CLMUL_CONSTANT);
+    
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        __m128i cl_lo = _mm_clmulepi64_si128(state->acc[i], clmul_k, 0x00);
+        __m128i cl_hi = _mm_clmulepi64_si128(state->acc[i], clmul_k, 0x11);
+        __m128i cl1   = _mm_xor_si128(cl_lo, cl_hi);
+        __m128i mid   = _mm_aesenc_si128(state->acc[i], cl1);
+        __m128i cl2   = _mm_clmulepi64_si128(mid, mid, 0x01);
+        
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_xor_si128(cl1, cl2));
+    }
+}
+
+TARGET_AESNI
+static void aesni_finalize_block_process(tachyon_aesni_state_t *state, __m128i d_pad[LANE_STRIDE],
+                                         uint64_t total_len, uint64_t domain, const __m128i rk_chain[10]) {
+    __m128i saves_final[LANE_STRIDE]; 
+    memcpy(saves_final, state->acc, REMAINDER_CHUNK_SIZE);
+    
+    __m128i meta[LANE_STRIDE] = {
+        _mm_set_epi64x(CHAOS_BASE, domain ^ total_len),
+        _mm_set_epi64x(domain,     total_len),
+        _mm_set_epi64x(total_len,  CHAOS_BASE),
+        _mm_set_epi64x(CHAOS_BASE, domain)
+    };
+    
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        state->acc[i] = _mm_xor_si128(state->acc[i], _mm_xor_si128(d_pad[i], meta[i]));
+    }
+    
+    for (int r = 0; r < 10; r++) {
+        __m128i rk = rk_chain[r];
+        
+        for (int i = 0; i < LANE_STRIDE; i++) {
+            state->acc[i] = _mm_aesenc_si128(state->acc[i], _mm_add_epi64(d_pad[i], rk));
+        }
+        
+        if (r % 2 == 1) {
+            __m128i t0 = state->acc[0];
+            __m128i t1 = state->acc[1];
+            __m128i t2 = state->acc[2];
+            __m128i t3 = state->acc[3];
+            
+            d_pad[0] = _mm_xor_si128(d_pad[0], t1);
+            d_pad[1] = _mm_xor_si128(d_pad[1], t2);
+            d_pad[2] = _mm_xor_si128(d_pad[2], t3);
+            d_pad[3] = _mm_xor_si128(d_pad[3], t0);
+        }
+        
+        rotate_lanes(state->acc, 0);
+    }
+    
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        state->acc[i] = _mm_xor_si128(state->acc[i], saves_final[i]);
+    }
+}
+
+TARGET_AESNI
+static void aesni_finalize_key_reabsorption(tachyon_aesni_state_t *state, const uint8_t *key) {
+    if (!key) return;
+    
+    __m128i k0 = _mm_loadu_si128((__m128i*)key);
+    __m128i k1 = _mm_loadu_si128((__m128i*)(key + VEC_SIZE));
+    
+    // Round 1
+    state->acc[0] = _mm_aesenc_si128(state->acc[0], k0); 
+    state->acc[1] = _mm_aesenc_si128(state->acc[1], k1);
+    state->acc[2] = _mm_aesenc_si128(state->acc[2], k1); 
+    state->acc[3] = _mm_aesenc_si128(state->acc[3], k0);
+    
+    // Round 2
+    state->acc[0] = _mm_aesenc_si128(state->acc[0], k1); 
+    state->acc[1] = _mm_aesenc_si128(state->acc[1], k0);
+    state->acc[2] = _mm_aesenc_si128(state->acc[2], k0); 
+    state->acc[3] = _mm_aesenc_si128(state->acc[3], k1);
+    
+    // Round 3
+    state->acc[0] = _mm_aesenc_si128(state->acc[0], k0); 
+    state->acc[1] = _mm_aesenc_si128(state->acc[1], k1);
+    state->acc[2] = _mm_aesenc_si128(state->acc[2], k0); 
+    state->acc[3] = _mm_aesenc_si128(state->acc[3], k1);
+    
+    // Round 4
+    state->acc[0] = _mm_aesenc_si128(state->acc[0], k0); 
+    state->acc[1] = _mm_aesenc_si128(state->acc[1], k0);
+    state->acc[2] = _mm_aesenc_si128(state->acc[2], k1); 
+    state->acc[3] = _mm_aesenc_si128(state->acc[3], k1);
+}
+
+TARGET_AESNI
+static void aesni_lane_reduction_4to256(__m128i acc[LANE_STRIDE], uint8_t *out) {
+    __m128i mrk0 = _mm_set1_epi64x(C5);
+    __m128i mrk1 = _mm_set1_epi64x(C6);
+    __m128i mrk2 = _mm_set1_epi64x(C7);
+    
+    __m128i a[LANE_STRIDE]; 
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        a[i] = _mm_aesenc_si128(acc[i], acc[i]);
+    }
+    
+    __m128i b0 = _mm_aesenc_si128(a[0], a[2]);
+    __m128i b1 = _mm_aesenc_si128(a[1], a[3]);
+    __m128i b2 = _mm_aesenc_si128(a[2], a[0]);
+    __m128i b3 = _mm_aesenc_si128(a[3], a[1]);
+    
+    __m128i c0 = _mm_aesenc_si128(b0, b1);
+    __m128i c1 = _mm_aesenc_si128(b1, _mm_xor_si128(b0, mrk2));
+    __m128i c2 = _mm_aesenc_si128(b2, _mm_xor_si128(b3, mrk1));
+    __m128i c3 = _mm_aesenc_si128(b3, _mm_xor_si128(b2, mrk0));
+    
+    __m128i out_l = _mm_aesenc_si128(c0, c2);
+    __m128i out_h = _mm_aesenc_si128(c1, c3);
+    
+    _mm_storeu_si128((__m128i*)out, _mm_aesenc_si128(out_l, out_h));
+    _mm_storeu_si128((__m128i*)(out + VEC_SIZE), _mm_aesenc_si128(out_h, _mm_xor_si128(out_l, mrk2)));
+}
+
+TARGET_AESNI
+void tachyon_aesni_finalize(tachyon_aesni_state_t *state, const uint8_t *remainder, size_t rem_len, 
+                            uint64_t total_len, uint64_t domain, const uint8_t *key, uint8_t *out) {
+    __m128i rk_chain[10];
+    for (int r = 0; r < 10; r++) {
+        rk_chain[r] = _mm_set_epi64x(RK_CHAIN[r][1], RK_CHAIN[r][0]);
+    }
+    
+    __m128i wk = _mm_set_epi64x((int64_t)WHITENING1, (int64_t)WHITENING0);
+    
+    /* 1. Remainder Chunks */
+    size_t processed = aesni_finalize_remainder_chunks(state, remainder, rem_len, wk, rk_chain);
+
+    /* 2. Final Padding Block */
+    uint8_t block[REMAINDER_CHUNK_SIZE] = {0};
+    size_t left = rem_len - processed;
+    
+    if (left > 0) {
+        memcpy(block, remainder + processed, left);
+    }
+    block[left] = 0x80;
+    
+    __m128i d_pad[LANE_STRIDE];
+    for (int j = 0; j < LANE_STRIDE; j++) {
+        d_pad[j] = _mm_aesenc_si128(_mm_loadu_si128((__m128i*)(block + j * VEC_SIZE)), wk);
+    }
+    
+    /* 3. Tree Merge (32 -> 16 -> 8 -> 4) */
+    aesni_finalize_tree_merge(state);
+
+    /* 4. Quadratic CLMUL Hardening */
+    aesni_finalize_clmul_hardening(state);
+    
+    /* 5. Final Block Processing */
+    aesni_finalize_block_process(state, d_pad, total_len, domain, rk_chain);
+    
+    /* 6. Key Re-absorption */
+    aesni_finalize_key_reabsorption(state, key);
+    
+    /* 7. Final Lane Reduction */
+    aesni_lane_reduction_4to256(state->acc, out);
+}
+
+// =============================================================================
+// SHORT PATH (0...63 bytes)
+// =============================================================================
+
+TARGET_AESNI
+static void aesni_short_initialize_state(__m128i acc[LANE_STRIDE]) {
+    acc[0] = _mm_set_epi64x(SHORT_INIT[0][1], SHORT_INIT[0][0]);
+    acc[1] = _mm_set_epi64x(SHORT_INIT[1][1], SHORT_INIT[1][0]);
+    acc[2] = _mm_set_epi64x(SHORT_INIT[2][1], SHORT_INIT[2][0]);
+    acc[3] = _mm_set_epi64x(SHORT_INIT[3][1], SHORT_INIT[3][0]);
+}
+
+TARGET_AESNI
+static void aesni_short_process_block(__m128i acc[LANE_STRIDE], const uint8_t *input, size_t len, uint64_t domain) {
+    __m128i rk_chain[10];
+    for (int r = 0; r < 10; r++) {
+        rk_chain[r] = _mm_set_epi64x(RK_CHAIN[r][1], RK_CHAIN[r][0]);
+    }
+    
+    __m128i wk = _mm_set_epi64x((int64_t)WHITENING1, (int64_t)WHITENING0);
+    
+    uint8_t block[REMAINDER_CHUNK_SIZE] = {0};
+    if (len > 0) {
+        memcpy(block, input, len);
+    }
+    block[len] = 0x80;
+    
+    __m128i d0 = _mm_aesenc_si128(_mm_loadu_si128((__m128i*)block), wk);
+    __m128i d1 = _mm_aesenc_si128(_mm_loadu_si128((__m128i*)(block + VEC_SIZE)), wk);
+    __m128i d2 = _mm_aesenc_si128(_mm_loadu_si128((__m128i*)(block + 32)), wk);
+    __m128i d3 = _mm_aesenc_si128(_mm_loadu_si128((__m128i*)(block + 48)), wk);
+    
+    __m128i saves[4] = {acc[0], acc[1], acc[2], acc[3]};
+
+    __m128i meta[LANE_STRIDE] = {
+        _mm_set_epi64x(CHAOS_BASE, domain ^ (uint64_t)len), 
+        _mm_set_epi64x(domain, (uint64_t)len),
+        _mm_set_epi64x((uint64_t)len, CHAOS_BASE), 
+        _mm_set_epi64x(CHAOS_BASE, domain)
+    };
+    
+    acc[0] = _mm_xor_si128(acc[0], _mm_xor_si128(d0, meta[0])); 
+    acc[1] = _mm_xor_si128(acc[1], _mm_xor_si128(d1, meta[1]));
+    acc[2] = _mm_xor_si128(acc[2], _mm_xor_si128(d2, meta[2])); 
+    acc[3] = _mm_xor_si128(acc[3], _mm_xor_si128(d3, meta[3]));
+    
+    for (int r = 0; r < 10; r++) {
+        __m128i rk = rk_chain[r];
+        
+        acc[0] = _mm_aesenc_si128(acc[0], _mm_add_epi64(d0, _mm_add_epi64(rk, _mm_set1_epi64x(LANE_OFFSETS[0]))));
+        acc[1] = _mm_aesenc_si128(acc[1], _mm_add_epi64(d1, _mm_add_epi64(rk, _mm_set1_epi64x(LANE_OFFSETS[1]))));
+        acc[2] = _mm_aesenc_si128(acc[2], _mm_add_epi64(d2, _mm_add_epi64(rk, _mm_set1_epi64x(LANE_OFFSETS[2]))));
+        acc[3] = _mm_aesenc_si128(acc[3], _mm_add_epi64(d3, _mm_add_epi64(rk, _mm_set1_epi64x(LANE_OFFSETS[3]))));
+        
+        if (r % 2 == 1) {
+            __m128i t0 = acc[0];
+            __m128i t1 = acc[1];
+            __m128i t2 = acc[2];
+            __m128i t3 = acc[3];
+            
+            d0 = _mm_xor_si128(d0, t1); 
+            d1 = _mm_xor_si128(d1, t2);
+            d2 = _mm_xor_si128(d2, t3); 
+            d3 = _mm_xor_si128(d3, t0);
+        }
+        rotate_lanes(acc, 0);
+    }
+    
+    for (int i = 0; i < 4; i++) {
+        acc[i] = _mm_xor_si128(acc[i], saves[i]);
+    }
+}
+
+TARGET_AESNI
+void tachyon_aesni_oneshot_short(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out) {
+    if (seed == 0 && !key) {
+        __m128i acc[4];
+        aesni_short_initialize_state(acc);
+        aesni_short_process_block(acc, input, len, domain);
+        aesni_lane_reduction_4to256(acc, out);
+    } else {
+        tachyon_aesni_state_t state;
+        tachyon_aesni_init(&state, key, seed);
+        tachyon_aesni_finalize(&state, input, len, len, domain, key, out);
+    }
+}
+
+// =============================================================================
+// INITIALIZATION
+// =============================================================================
+
+TARGET_AESNI
+void tachyon_aesni_init(tachyon_aesni_state_t *state, const uint8_t *key, uint64_t seed) {
+    uint64_t C_VALS[NUM_LANES] = {C0, C1, C2, C3, C4, C5, C6, C7};
+    for (int i = 0; i < NUM_LANES; i++) {
+        uint64_t base = C_VALS[i];
+        state->acc[ACC_INDEX(i, 0)] = init_reg(base);
+        state->acc[ACC_INDEX(i, 1)] = init_reg(base + 2);
+        state->acc[ACC_INDEX(i, 2)] = init_reg(base + 4);
+        state->acc[ACC_INDEX(i, 3)] = init_reg(base + 6);
+    }
+    
+    __m128i s_vec = (seed != 0) ? _mm_set1_epi64x(seed) : _mm_set1_epi64x(C5);
+    for (int i = 0; i < 32; i++) {
+        state->acc[i] = _mm_aesenc_si128(state->acc[i], s_vec);
+    }
+    
+    if (key) {
+        __m128i k0 = _mm_loadu_si128((__m128i*)key);
+        __m128i k1 = _mm_loadu_si128((__m128i*)(key + VEC_SIZE));
+        __m128i gr = _mm_set1_epi64x(GOLDEN_RATIO);
+        __m128i k2 = _mm_xor_si128(k0, gr);
+        __m128i k3 = _mm_xor_si128(k1, gr);
+
+        for (int i = 0; i < NUM_LANES; i++) {
+            __m128i lo = _mm_set1_epi64x(LANE_OFFSETS[i]);
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                __m128i k = (j == 0) ? k0 : (j == 1) ? k1 : (j == 2) ? k2 : k3;
+                state->acc[ACC_INDEX(i, j)] = _mm_aesenc_si128(state->acc[ACC_INDEX(i, j)], _mm_add_epi64(k, lo));
+                state->acc[ACC_INDEX(i, j)] = _mm_aesenc_si128(state->acc[ACC_INDEX(i, j)], k);
+            }
+        }
+    }
+    state->block_count = 0;
+}
+
+// =============================================================================
+// COMPRESSION
+// =============================================================================
+
+TARGET_AESNI
+void tachyon_aesni_update(tachyon_aesni_state_t *state, const uint8_t *input, size_t len) {
+    __m128i rk_base[10];
+    for (int r = 0; r < 10; r++) {
+        rk_base[r] = _mm_set_epi64x(RK_CHAIN[r][1], RK_CHAIN[r][0]);
+    }
+    
+    __m128i wk = _mm_set_epi64x((int64_t)WHITENING1, (int64_t)WHITENING0);
+    
+    __m128i lo_all[32];
+    for (int i = 0; i < 32; i++) {
+        lo_all[i] = _mm_set1_epi64x(LANE_OFFSETS[i]);
+    }
+
+    size_t processed = 0;
+    while (processed + BLOCK_SIZE <= len) {
+        __m128i saves[32];
+        memcpy(saves, state->acc, BLOCK_SIZE);
+        
+        const uint8_t *b_ptr = input + processed;
+        __m128i blk = _mm_set1_epi64x(state->block_count);
+
+        __m128i d[NUM_LANES][LANE_STRIDE];
+        for (int i = 0; i < NUM_LANES; i++) {
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                d[i][j] = _mm_aesenc_si128(_mm_loadu_si128((__m128i*)(b_ptr + i * (LANE_STRIDE * VEC_SIZE) + j * VEC_SIZE)), wk);
+            }
+        }
+
+        /* Phase 1: Round-Robin Mix (Direct Mapping) */
+        aesni_compress_phase1_roundrobin(state, d, rk_base, lo_all, blk);
+
+        /* Mid-block mixing: Intra-register lane rotation */
+        aesni_compress_midblock_mixing(state);
+
+        /* Phase 2: Completion (Offset Mapping) */
+        aesni_compress_phase2_and_feedforward(state, d, rk_base, lo_all, blk, saves);
+
+        state->block_count++;
+        processed += BLOCK_SIZE;
+    }
+}
+
+// =============================================================================
+// PUBLIC API
+// =============================================================================
+
+TARGET_AESNI
+void tachyon_aesni_oneshot(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out) {
+    if (len < REMAINDER_CHUNK_SIZE) {
+        tachyon_aesni_oneshot_short(input, len, domain, seed, key, out);
+        return;
+    }
+    
+    tachyon_aesni_state_t state;
+    tachyon_aesni_init(&state, key, seed);
+    
+    size_t chunk_len = (len / BLOCK_SIZE) * BLOCK_SIZE;
+    if (chunk_len > 0) {
+        tachyon_aesni_update(&state, input, chunk_len);
+    }
+    
+    tachyon_aesni_finalize(&state, input + chunk_len, len - chunk_len, len, domain, key, out);
+}
+
+#endif // x86_64 or i386

--- a/tachyon/tachyon_avx512.c
+++ b/tachyon/tachyon_avx512.c
@@ -1,0 +1,490 @@
+// Tachyon
+// Copyright (c) byt3forg3
+// Licensed under the MIT or Apache 2.0 License
+// -------------------------------------------------------------------------
+
+#include <stdint.h>
+#include <string.h>
+#include "tachyon_impl.h"
+
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+
+#include <immintrin.h>
+// =============================================================================
+// AVX-512 KERNEL
+// =============================================================================
+
+#if defined(__GNUC__) || defined(__clang__)
+  #define TARGET_AVX512 __attribute__((target("avx512f,avx512bw,vaes,vpclmulqdq")))
+#else
+  #define TARGET_AVX512
+#endif
+
+typedef struct {
+    __m512i acc[NUM_LANES];
+    uint64_t block_count;
+} tachyon_avx512_state_t;
+
+TARGET_AVX512
+static inline __m512i init_reg(uint64_t base) {
+    return _mm512_set_epi64(
+        base + 7, base + 6, base + 5, base + 4,
+        base + 3, base + 2, base + 1, base
+    );
+}
+
+// =============================================================================
+// COMPRESSION HELPERS
+// =============================================================================
+
+#define AES_MIX(acc, data, rk, lo, blk) \
+    _mm512_aesenc_epi128(acc, _mm512_add_epi64(data, _mm512_add_epi64(rk, _mm512_add_epi64(lo, blk))))
+
+TARGET_AVX512
+static void avx512_compress_phase1_roundrobin(
+    tachyon_avx512_state_t *state,
+    __m512i *d0, __m512i *d1, __m512i *d2, __m512i *d3,
+    __m512i *d4, __m512i *d5, __m512i *d6, __m512i *d7,
+    const __m512i rk_base[10], const __m512i lo[NUM_LANES], __m512i blk) 
+{
+    for (int r = 0; r < 5; r++) {
+        __m512i rk = rk_base[r];
+        state->acc[0] = AES_MIX(state->acc[0], *d0, rk, lo[0], blk);
+        state->acc[1] = AES_MIX(state->acc[1], *d1, rk, lo[1], blk);
+        state->acc[2] = AES_MIX(state->acc[2], *d2, rk, lo[2], blk);
+        state->acc[3] = AES_MIX(state->acc[3], *d3, rk, lo[3], blk);
+        state->acc[4] = AES_MIX(state->acc[4], *d4, rk, lo[4], blk);
+        state->acc[5] = AES_MIX(state->acc[5], *d5, rk, lo[5], blk);
+        state->acc[6] = AES_MIX(state->acc[6], *d6, rk, lo[6], blk);
+        state->acc[7] = AES_MIX(state->acc[7], *d7, rk, lo[7], blk);
+
+        *d0 = _mm512_xor_si512(*d0, state->acc[3]);
+        *d1 = _mm512_xor_si512(*d1, state->acc[4]);
+        *d2 = _mm512_xor_si512(*d2, state->acc[5]);
+        *d3 = _mm512_xor_si512(*d3, state->acc[6]);
+        *d4 = _mm512_xor_si512(*d4, state->acc[7]);
+        *d5 = _mm512_xor_si512(*d5, state->acc[0]);
+        *d6 = _mm512_xor_si512(*d6, state->acc[1]);
+        *d7 = _mm512_xor_si512(*d7, state->acc[2]);
+
+        __m512i tmp = state->acc[0];
+        state->acc[0] = state->acc[1]; 
+        state->acc[1] = state->acc[2]; 
+        state->acc[2] = state->acc[3]; 
+        state->acc[3] = state->acc[4];
+        state->acc[4] = state->acc[5]; 
+        state->acc[5] = state->acc[6]; 
+        state->acc[6] = state->acc[7]; 
+        state->acc[7] = tmp;
+    }
+}
+
+TARGET_AVX512
+static void avx512_compress_midblock_mixing(tachyon_avx512_state_t *state) {
+    for (int i = 0; i < NUM_LANES; i++) {
+        state->acc[i] = _mm512_alignr_epi64(state->acc[i], state->acc[i], 2);
+    }
+
+    /* Cross-Accumulator Diffusion Stage 1 */
+    __m512i tmp_lo[4] = {
+        state->acc[0], state->acc[1], state->acc[2], state->acc[3]
+    };
+    
+    state->acc[0] = _mm512_xor_si512(state->acc[0], state->acc[4]);
+    state->acc[1] = _mm512_xor_si512(state->acc[1], state->acc[5]);
+    state->acc[2] = _mm512_xor_si512(state->acc[2], state->acc[6]);
+    state->acc[3] = _mm512_xor_si512(state->acc[3], state->acc[7]);
+    
+    state->acc[4] = _mm512_add_epi64(state->acc[4], tmp_lo[0]);
+    state->acc[5] = _mm512_add_epi64(state->acc[5], tmp_lo[1]);
+    state->acc[6] = _mm512_add_epi64(state->acc[6], tmp_lo[2]);
+    state->acc[7] = _mm512_add_epi64(state->acc[7], tmp_lo[3]);
+
+    /* Cross-Accumulator Diffusion Stage 2 */
+    __m512i bf0 = state->acc[0];
+    __m512i bf1 = state->acc[1];
+    __m512i bf4 = state->acc[4];
+    __m512i bf5 = state->acc[5];
+    
+    state->acc[0] = _mm512_xor_si512(state->acc[0], state->acc[2]);
+    state->acc[2] = _mm512_add_epi64(state->acc[2], bf0);
+    
+    state->acc[1] = _mm512_xor_si512(state->acc[1], state->acc[3]);
+    state->acc[3] = _mm512_add_epi64(state->acc[3], bf1);
+    
+    state->acc[4] = _mm512_xor_si512(state->acc[4], state->acc[6]);
+    state->acc[6] = _mm512_add_epi64(state->acc[6], bf4);
+    
+    state->acc[5] = _mm512_xor_si512(state->acc[5], state->acc[7]);
+    state->acc[7] = _mm512_add_epi64(state->acc[7], bf5);
+}
+
+TARGET_AVX512
+static void avx512_compress_phase2_and_feedforward(
+    tachyon_avx512_state_t *state,
+    __m512i *d0, __m512i *d1, __m512i *d2, __m512i *d3,
+    __m512i *d4, __m512i *d5, __m512i *d6, __m512i *d7,
+    const __m512i rk_base[10], const __m512i lo[NUM_LANES], 
+    __m512i blk, const __m512i saves[NUM_LANES]) 
+{
+    for (int r = 5; r < 10; r++) {
+        __m512i rk = rk_base[r];
+        state->acc[0] = AES_MIX(state->acc[0], *d4, rk, lo[0], blk);
+        state->acc[1] = AES_MIX(state->acc[1], *d5, rk, lo[1], blk);
+        state->acc[2] = AES_MIX(state->acc[2], *d6, rk, lo[2], blk);
+        state->acc[3] = AES_MIX(state->acc[3], *d7, rk, lo[3], blk);
+        state->acc[4] = AES_MIX(state->acc[4], *d0, rk, lo[4], blk);
+        state->acc[5] = AES_MIX(state->acc[5], *d1, rk, lo[5], blk);
+        state->acc[6] = AES_MIX(state->acc[6], *d2, rk, lo[6], blk);
+        state->acc[7] = AES_MIX(state->acc[7], *d3, rk, lo[7], blk);
+        
+        *d0 = _mm512_xor_si512(*d0, state->acc[3]);
+        *d1 = _mm512_xor_si512(*d1, state->acc[4]);
+        *d2 = _mm512_xor_si512(*d2, state->acc[5]);
+        *d3 = _mm512_xor_si512(*d3, state->acc[6]);
+        *d4 = _mm512_xor_si512(*d4, state->acc[7]);
+        *d5 = _mm512_xor_si512(*d5, state->acc[0]);
+        *d6 = _mm512_xor_si512(*d6, state->acc[1]);
+        *d7 = _mm512_xor_si512(*d7, state->acc[2]);
+        
+        __m512i tmp = state->acc[0];
+        state->acc[0] = state->acc[1]; 
+        state->acc[1] = state->acc[2]; 
+        state->acc[2] = state->acc[3]; 
+        state->acc[3] = state->acc[4];
+        state->acc[4] = state->acc[5]; 
+        state->acc[5] = state->acc[6]; 
+        state->acc[6] = state->acc[7]; 
+        state->acc[7] = tmp;
+    }
+
+    /* Davies-Meyer Feed-Forward */
+    for (int i = 0; i < NUM_LANES; i++) {
+        state->acc[i] = _mm512_alignr_epi64(state->acc[i], state->acc[i], 2);
+    }
+    for (int i = 0; i < NUM_LANES; i++) {
+        state->acc[i] = _mm512_xor_si512(state->acc[i], saves[i]);
+    }
+}
+
+// =============================================================================
+// FINALIZATION HELPERS
+// =============================================================================
+
+TARGET_AVX512
+static size_t avx512_finalize_remainder_chunks(
+    tachyon_avx512_state_t *state, const uint8_t *remainder, size_t rem_len, 
+    __m512i wk, const __m512i rk_chain[10]) 
+{
+    const uint8_t *ptr = remainder;
+    size_t offset = 0;
+    
+    for (int i = 0; i < NUM_LANES; i++) {
+        if (offset + REMAINDER_CHUNK_SIZE <= rem_len) {
+            __m512i d = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + offset), wk);
+            int base = i * 4;
+            
+            __m512i lo_f = _mm512_set_epi64(
+                LANE_OFFSETS[base+3], LANE_OFFSETS[base+3],
+                LANE_OFFSETS[base+2], LANE_OFFSETS[base+2],
+                LANE_OFFSETS[base+1], LANE_OFFSETS[base+1],
+                LANE_OFFSETS[base],   LANE_OFFSETS[base]
+            );
+            
+            __m512i save = state->acc[i];
+            
+            for (int r = 0; r < 10; r++) {
+                state->acc[i] = _mm512_aesenc_epi128(state->acc[i], _mm512_add_epi64(d, _mm512_add_epi64(rk_chain[r], lo_f)));
+                state->acc[i] = _mm512_alignr_epi64(state->acc[i], state->acc[i], 2);
+                d = _mm512_xor_si512(d, state->acc[i]);
+            }
+            
+            state->acc[i] = _mm512_xor_si512(state->acc[i], save);
+            offset += REMAINDER_CHUNK_SIZE;
+        }
+    }
+    
+    return offset;
+}
+
+TARGET_AVX512
+static void avx512_finalize_tree_merge(tachyon_avx512_state_t *state) {
+    __m512i mrk0 = _mm512_set1_epi64(C5);
+    __m512i mrk1 = _mm512_set1_epi64(C6);
+    __m512i mrk2 = _mm512_set1_epi64(C7);
+
+    for (int i = 0; i < 4; i++) {
+        state->acc[i] = _mm512_aesenc_epi128(state->acc[i], _mm512_xor_si512(state->acc[i+4], mrk0));
+        state->acc[i] = _mm512_aesenc_epi128(state->acc[i], _mm512_xor_si512(state->acc[i],   mrk0));
+    }
+    
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_xor_si512(state->acc[2], mrk1));
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_xor_si512(state->acc[0], mrk1));
+    
+    state->acc[1] = _mm512_aesenc_epi128(state->acc[1], _mm512_xor_si512(state->acc[3], mrk1));
+    state->acc[1] = _mm512_aesenc_epi128(state->acc[1], _mm512_xor_si512(state->acc[1], mrk1));
+    
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_xor_si512(state->acc[1], mrk2));
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_xor_si512(state->acc[0], mrk2));
+}
+
+TARGET_AVX512
+static void avx512_finalize_clmul_hardening(tachyon_avx512_state_t *state) {
+    __m512i clmul_k = _mm512_set_epi64(
+         CLMUL_CONSTANT2, CLMUL_CONSTANT, 
+         CLMUL_CONSTANT2, CLMUL_CONSTANT, 
+         CLMUL_CONSTANT2, CLMUL_CONSTANT, 
+         CLMUL_CONSTANT2, CLMUL_CONSTANT
+    );
+    
+    __m512i cl_lo = _mm512_clmulepi64_epi128(state->acc[0], clmul_k, 0x00);
+    __m512i cl_hi = _mm512_clmulepi64_epi128(state->acc[0], clmul_k, 0x11);
+    __m512i cl1   = _mm512_xor_si512(cl_lo, cl_hi);
+    __m512i mid   = _mm512_aesenc_epi128(state->acc[0], cl1);
+    __m512i cl2   = _mm512_clmulepi64_epi128(mid, mid, 0x01);
+    
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_xor_si512(cl1, cl2));
+}
+
+TARGET_AVX512
+static void avx512_finalize_block_process(
+    tachyon_avx512_state_t *state, __m512i d_pad, 
+    uint64_t total_len, uint64_t domain, 
+    const __m512i rk_chain[10], __m512i save_final) 
+{
+    __m512i meta_vec = _mm512_set_epi64(
+        CHAOS_BASE, domain, total_len, CHAOS_BASE,
+        domain, total_len, CHAOS_BASE, domain ^ total_len
+    );
+    
+    state->acc[0] = _mm512_ternarylogic_epi64(state->acc[0], d_pad, meta_vec, 0x96); // XOR 3 vectors
+    
+    for (int r = 0; r < 10; r++) {
+        state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_add_epi64(d_pad, rk_chain[r]));
+        state->acc[0] = _mm512_alignr_epi64(state->acc[0], state->acc[0], 2);
+        
+        if (r % 2 == 1) {
+            d_pad = _mm512_xor_si512(d_pad, state->acc[0]);
+        }
+    }
+    
+    state->acc[0] = _mm512_xor_si512(state->acc[0], save_final);
+}
+
+TARGET_AVX512
+static void avx512_finalize_key_reabsorption(tachyon_avx512_state_t *state, const uint8_t *key) {
+    if (!key) return;
+    
+    uint8_t key_padding[REMAINDER_CHUNK_SIZE];
+    memcpy(key_padding,             key, HASH_SIZE);
+    memcpy(key_padding + HASH_SIZE, key, HASH_SIZE);
+    
+    __m512i k0_f = _mm512_loadu_si512(key_padding);
+    __m512i gr_f = _mm512_set_epi64(GOLDEN_RATIO, GOLDEN_RATIO, GOLDEN_RATIO, GOLDEN_RATIO, 0, 0, 0, 0);
+    k0_f = _mm512_xor_si512(k0_f, gr_f);
+    
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_shuffle_i32x4(k0_f, k0_f, 0x14));
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_shuffle_i32x4(k0_f, k0_f, 0x41));
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_shuffle_i32x4(k0_f, k0_f, 0x44));
+    state->acc[0] = _mm512_aesenc_epi128(state->acc[0], _mm512_shuffle_i32x4(k0_f, k0_f, 0x50));
+}
+
+TARGET_AVX512
+static void avx512_lane_reduction_4to256(__m512i acc_zero, uint8_t *out) {
+    __m512i asymmetry = _mm512_set_epi64(C5, C5, C6, C6, C7, C7, 0, 0); 
+    
+    __m512i mix = _mm512_aesenc_epi128(acc_zero, acc_zero);
+    mix = _mm512_aesenc_epi128(mix, _mm512_shuffle_i32x4(mix, mix, 0x4E));
+    
+    __m512i mix_s = _mm512_shuffle_i32x4(mix, mix, 0xB1);
+    mix = _mm512_aesenc_epi128(mix, _mm512_xor_si512(mix_s, asymmetry));
+    
+    mix = _mm512_aesenc_epi128(mix, _mm512_shuffle_i32x4(mix, mix, 0x4E));
+    mix_s = _mm512_shuffle_i32x4(mix, mix, 0xB1);
+    mix = _mm512_aesenc_epi128(mix, _mm512_xor_si512(mix_s, asymmetry));
+    
+    _mm_storeu_si128((__m128i*)out, _mm512_castsi512_si128(mix));
+    _mm_storeu_si128((__m128i*)(out + VEC_SIZE), _mm512_castsi512_si128(_mm512_shuffle_i32x4(mix, mix, 0x01)));
+}
+
+// External short-path fallback.
+extern void tachyon_aesni_oneshot_short(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out);
+
+// =============================================================================
+// INITIALIZATION
+// =============================================================================
+
+TARGET_AVX512
+void tachyon_avx512_init(tachyon_avx512_state_t *state, const uint8_t *key, uint64_t seed) {
+    state->acc[0] = init_reg(C0);
+    state->acc[1] = init_reg(C1);
+    state->acc[2] = init_reg(C2);
+    state->acc[3] = init_reg(C3);
+    state->acc[4] = init_reg(C4);
+    state->acc[5] = init_reg(C5);
+    state->acc[6] = init_reg(C6);
+    state->acc[7] = init_reg(C7);
+
+    __m512i s_vec = (seed != 0) ? _mm512_set1_epi64(seed) : _mm512_set1_epi64(C5);
+    for (int i = 0; i < NUM_LANES; i++) {
+        state->acc[i] = _mm512_aesenc_epi128(state->acc[i], s_vec);
+    }
+
+    if (key) {
+        uint8_t key_block[REMAINDER_CHUNK_SIZE];
+        memcpy(key_block,             key, HASH_SIZE);
+        memcpy(key_block + HASH_SIZE, key, HASH_SIZE);
+
+        __m512i k_vec = _mm512_loadu_si512(key_block);
+
+        __m512i gr_mask = _mm512_set_epi64(
+            GOLDEN_RATIO, GOLDEN_RATIO, GOLDEN_RATIO, GOLDEN_RATIO,
+            0, 0, 0, 0
+        );
+        k_vec = _mm512_xor_si512(k_vec, gr_mask);
+        
+        for (int i = 0; i < NUM_LANES; i++) {
+            __m512i lo_k  = _mm512_add_epi64(k_vec, _mm512_set1_epi64(LANE_OFFSETS[i]));
+            state->acc[i] = _mm512_aesenc_epi128(state->acc[i], lo_k);
+            state->acc[i] = _mm512_aesenc_epi128(state->acc[i], k_vec);
+        }
+    }
+    state->block_count = 0;
+}
+
+// =============================================================================
+// COMPRESSION
+// =============================================================================
+
+TARGET_AVX512
+void tachyon_avx512_update(tachyon_avx512_state_t *state, const uint8_t *input, size_t len) {
+    __m512i rk_base[10];
+    for (int r = 0; r < 10; r++) {
+        rk_base[r] = _mm512_set_epi64(
+            RK_CHAIN[r][1], RK_CHAIN[r][0], RK_CHAIN[r][1], RK_CHAIN[r][0],
+            RK_CHAIN[r][1], RK_CHAIN[r][0], RK_CHAIN[r][1], RK_CHAIN[r][0]
+        );
+    }
+
+    __m512i lo[NUM_LANES];
+    for (int i = 0; i < NUM_LANES; i++) {
+        int base = i * 4;
+        lo[i] = _mm512_set_epi64(
+            LANE_OFFSETS[base+3], LANE_OFFSETS[base+3],
+            LANE_OFFSETS[base+2], LANE_OFFSETS[base+2],
+            LANE_OFFSETS[base+1], LANE_OFFSETS[base+1],
+            LANE_OFFSETS[base],   LANE_OFFSETS[base]
+        );
+    }
+    
+    __m512i wk = _mm512_set_epi64(
+        WHITENING1, WHITENING0, WHITENING1, WHITENING0, 
+        WHITENING1, WHITENING0, WHITENING1, WHITENING0
+    );
+    
+    size_t processed = 0;
+    while (processed + BLOCK_SIZE <= len) {
+        const uint8_t *ptr = input + processed;
+        __m512i blk = _mm512_set1_epi64(state->block_count);
+
+        __m512i d0 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr),       wk);
+        __m512i d1 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + 64),  wk);
+        __m512i d2 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + 128), wk);
+        __m512i d3 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + 192), wk);
+        __m512i d4 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + 256), wk);
+        __m512i d5 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + 320), wk);
+        __m512i d6 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + 384), wk);
+        __m512i d7 = _mm512_aesenc_epi128(_mm512_loadu_si512(ptr + 448), wk);
+        
+        __m512i saves[NUM_LANES];
+        for (int i = 0; i < NUM_LANES; i++) saves[i] = state->acc[i];
+
+        /* Phase 1: Round-Robin Mix (Direct Mapping) */
+        avx512_compress_phase1_roundrobin(state, &d0, &d1, &d2, &d3, &d4, &d5, &d6, &d7, rk_base, lo, blk);
+
+        /* Mid-block mixing: Intra-register lane rotation */
+        avx512_compress_midblock_mixing(state);
+
+        /* Phase 2: Completion (Offset Mapping) */
+        avx512_compress_phase2_and_feedforward(state, &d0, &d1, &d2, &d3, &d4, &d5, &d6, &d7, rk_base, lo, blk, saves);
+
+        processed += BLOCK_SIZE;
+        state->block_count++;
+    }
+}
+
+// =============================================================================
+// FINALIZATION
+// =============================================================================
+
+TARGET_AVX512
+void tachyon_avx512_finalize(
+    tachyon_avx512_state_t *state, const uint8_t *remainder, size_t rem_len, 
+    uint64_t total_len, uint64_t domain, const uint8_t *key, uint8_t *out) 
+{
+    __m512i rk_chain[10];
+    for (int r = 0; r < 10; r++) {
+        rk_chain[r] = _mm512_set_epi64(
+            RK_CHAIN[r][1], RK_CHAIN[r][0], RK_CHAIN[r][1], RK_CHAIN[r][0],
+            RK_CHAIN[r][1], RK_CHAIN[r][0], RK_CHAIN[r][1], RK_CHAIN[r][0]
+        );
+    }
+    __m512i wk = _mm512_set_epi64(
+        WHITENING1, WHITENING0, WHITENING1, WHITENING0, 
+        WHITENING1, WHITENING0, WHITENING1, WHITENING0
+    );
+
+    /* 1. Remainder Chunks */
+    size_t processed = avx512_finalize_remainder_chunks(state, remainder, rem_len, wk, rk_chain);
+
+    /* 2. Final Padding Block */
+    uint8_t block[REMAINDER_CHUNK_SIZE] = {0};
+    size_t left = rem_len - processed;
+    
+    if (left > 0) {
+        memcpy(block, remainder + processed, left);
+    }
+    block[left] = 0x80;
+    __m512i d_pad = _mm512_aesenc_epi128(_mm512_loadu_si512(block), wk);
+
+    /* 3. Tree Merge (8 -> 4 -> 2 -> 1) */
+    avx512_finalize_tree_merge(state);
+
+    /* 4. Quadratic CLMUL Hardening */
+    avx512_finalize_clmul_hardening(state);
+    
+    __m512i save_final = state->acc[0];
+
+    /* 5. Final Block Processing */
+    avx512_finalize_block_process(state, d_pad, total_len, domain, rk_chain, save_final);
+
+    /* 6. Key Re-absorption */
+    avx512_finalize_key_reabsorption(state, key);
+
+    /* 7. Final Lane Reduction */
+    avx512_lane_reduction_4to256(state->acc[0], out);
+}
+
+// =============================================================================
+// PUBLIC API
+// =============================================================================
+
+TARGET_AVX512
+void tachyon_avx512_oneshot(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out) {
+    if (len < REMAINDER_CHUNK_SIZE) {
+        tachyon_aesni_oneshot_short(input, len, domain, seed, key, out);
+        return;
+    }
+    
+    tachyon_avx512_state_t state;
+    tachyon_avx512_init(&state, key, seed);
+    
+    size_t chunk_len = (len / BLOCK_SIZE) * BLOCK_SIZE;
+    if (chunk_len > 0) {
+        tachyon_avx512_update(&state, input, chunk_len);
+    }
+    
+    tachyon_avx512_finalize(&state, input + chunk_len, len - chunk_len, len, domain, key, out);
+}
+
+#endif // x86_64 or i386

--- a/tachyon/tachyon_dispatcher.c
+++ b/tachyon/tachyon_dispatcher.c
@@ -1,0 +1,381 @@
+// Tachyon
+// Copyright (c) byt3forg3
+// Licensed under the MIT or Apache 2.0 License
+// -------------------------------------------------------------------------
+
+#include "tachyon.h"
+#include "tachyon_impl.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <cpuid.h>
+#endif
+#endif
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+#define CHUNK_SIZE (256 * 1024)
+#define MAX_TREE_LEVELS 64
+
+#define XCR0_SSE_AVX_MASK 0x06
+#define XCR0_AVX512_MASK  0xE0
+
+// CPUID feature bit positions
+#define CPUID_AES_BIT       25
+#define CPUID_AVX512F_BIT   16
+#define CPUID_AVX512BW_BIT  30
+#define CPUID_VAES_BIT       9
+#define CPUID_VPCLMUL_BIT   10
+
+typedef enum {
+    CPU_UNKNOWN = 0,
+    CPU_PORTABLE = 1,
+    CPU_AESNI = 2,
+    CPU_AVX512 = 3
+} cpu_feature_t;
+
+// =============================================================================
+// CPU FEATURE DETECTION
+// =============================================================================
+
+static cpu_feature_t g_cpu_feature = CPU_UNKNOWN;
+
+static void detect_cpu() {
+#ifdef FORCE_PORTABLE
+    g_cpu_feature = CPU_PORTABLE;
+#elif defined(FORCE_AESNI) && (defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86))
+    g_cpu_feature = CPU_AESNI;
+#elif defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+    unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+
+#if defined(_MSC_VER)
+    int cpuInfo[4];
+    __cpuid(cpuInfo, 1);
+    eax = cpuInfo[0]; ebx = cpuInfo[1]; ecx = cpuInfo[2]; edx = cpuInfo[3];
+    int cpuid_ok = 1;
+#else
+    int cpuid_ok = __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+#endif
+
+    if (!cpuid_ok || !(ecx & (1 << CPUID_AES_BIT))) {
+        g_cpu_feature = CPU_PORTABLE;
+    } else {
+        g_cpu_feature = CPU_AESNI;
+
+#if defined(_MSC_VER)
+        __cpuidex(cpuInfo, 7, 0);
+        eax = cpuInfo[0]; ebx = cpuInfo[1]; ecx = cpuInfo[2]; edx = cpuInfo[3];
+        int cpuid7_ok = 1;
+#else
+        int cpuid7_ok = __get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx);
+#endif
+
+        if (cpuid7_ok) {
+            int has_avx512_cpuid =
+                (ebx & (1 << CPUID_AVX512F_BIT))  &&  /* AVX-512 Foundation  */
+                (ebx & (1 << CPUID_AVX512BW_BIT)) &&  /* AVX-512 Byte/Word   */
+                (ecx & (1 << CPUID_VAES_BIT))     &&  /* Vector AES          */
+                (ecx & (1 << CPUID_VPCLMUL_BIT));     /* Vector CLMUL        */
+
+            if (has_avx512_cpuid) {
+                /* Verify OS support: check XCR0 for ZMM state saving.
+                 * Prevents crashes in VMs that mask AVX-512 at the hypervisor level.
+                 * Uses inline asm to avoid requiring -mxsave compiler flag. */
+                uint32_t xcr0_lo, xcr0_hi;
+#if defined(_MSC_VER)
+                uint64_t xcr0 = _xgetbv(0);
+                xcr0_lo = (uint32_t)xcr0;
+                xcr0_hi = (uint32_t)(xcr0 >> 32);
+#else
+                __asm__ volatile ("xgetbv" : "=a"(xcr0_lo), "=d"(xcr0_hi) : "c"(0));
+#endif
+
+                if ((xcr0_lo & XCR0_SSE_AVX_MASK) == XCR0_SSE_AVX_MASK &&
+                    (xcr0_lo & XCR0_AVX512_MASK)  == XCR0_AVX512_MASK) {
+                    g_cpu_feature = CPU_AVX512;
+                }
+            }
+        }
+    }
+#else
+    g_cpu_feature = CPU_PORTABLE;
+#endif
+}
+
+const char* tachyon_get_backend_name(void) {
+    if (g_cpu_feature == CPU_UNKNOWN) detect_cpu();
+    switch (g_cpu_feature) {
+#if !defined(FORCE_PORTABLE) && (defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86))
+        case CPU_AVX512: return "AVX-512 (Truck)";
+        case CPU_AESNI:  return "AES-NI (Scooter)";
+#endif
+        default:         return "Portable";
+    }
+}
+
+typedef void (*tachyon_oneshot_fn)(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out);
+
+static tachyon_oneshot_fn get_kernel() {
+    if (g_cpu_feature == CPU_UNKNOWN) detect_cpu();
+#if !defined(FORCE_PORTABLE) && (defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86))
+    if (g_cpu_feature == CPU_AVX512) return tachyon_avx512_oneshot;
+    if (g_cpu_feature == CPU_AESNI)  return tachyon_aesni_oneshot;
+#endif
+    return tachyon_portable_oneshot;
+}
+
+static void compute_kernel(const uint8_t *data, size_t len, uint64_t domain,
+                           uint64_t seed, const uint8_t *key, uint8_t *out) {
+    get_kernel()(data, len, domain, seed, key, out);
+}
+
+// =============================================================================
+// MERKLE TREE ENGINE
+// =============================================================================
+
+typedef struct {
+    uint8_t buffer[CHUNK_SIZE];
+    size_t buffer_len;
+    uint64_t total_len;
+    uint64_t domain;
+    uint64_t seed;
+    uint8_t key[HASH_SIZE];
+    int has_key;
+    uint8_t stack[MAX_TREE_LEVELS][HASH_SIZE];
+    uint64_t stack_usage;
+} tachyon_internal_state_t;
+
+/* Merkle tree stack push using bitfield-based sparse representation. */
+static void stack_push(tachyon_internal_state_t *s, const uint8_t *hash) {
+    uint8_t current_hash[HASH_SIZE];
+    memcpy(current_hash, hash, HASH_SIZE);
+
+    for (int level = 0; level < MAX_TREE_LEVELS; level++) {
+        if (s->stack_usage & (1ULL << level)) {
+            uint8_t buffer[HASH_SIZE * 2];
+            memcpy(buffer,             &s->stack[level], HASH_SIZE);
+            memcpy(buffer + HASH_SIZE, current_hash,     HASH_SIZE);
+            compute_kernel(buffer, HASH_SIZE * 2, DOMAIN_NODE, s->seed,
+                           s->has_key ? s->key : NULL, current_hash);
+            s->stack_usage &= ~(1ULL << level);
+        } else {
+            memcpy(&s->stack[level], current_hash, HASH_SIZE);
+            s->stack_usage |= (1ULL << level);
+            return;
+        }
+    }
+}
+
+static tachyon_internal_state_t* new_state(uint64_t domain, uint64_t seed, const uint8_t *key) {
+    tachyon_internal_state_t *s = (tachyon_internal_state_t*)malloc(sizeof(tachyon_internal_state_t));
+    if (!s) return NULL;
+    memset(s, 0, sizeof(*s));
+    s->domain = domain;
+    s->seed   = seed;
+    if (key) {
+        memcpy(s->key, key, HASH_SIZE);
+        s->has_key = 1;
+    }
+    return s;
+}
+
+static void update_state(tachyon_internal_state_t *state, const uint8_t *data, size_t len) {
+    size_t processed = 0;
+
+    while (processed < len) {
+        size_t copy_len = CHUNK_SIZE - state->buffer_len;
+        if (len - processed < copy_len) {
+            copy_len = len - processed;
+        }
+
+        memcpy(state->buffer + state->buffer_len, data + processed, copy_len);
+        state->buffer_len += copy_len;
+        state->total_len  += copy_len;
+        processed         += copy_len;
+
+        if (state->buffer_len == CHUNK_SIZE) {
+            uint8_t chunk_hash[HASH_SIZE];
+            compute_kernel(state->buffer, CHUNK_SIZE, DOMAIN_LEAF, state->seed,
+                           state->has_key ? state->key : NULL, chunk_hash);
+            stack_push(state, chunk_hash);
+            state->buffer_len = 0;
+        }
+    }
+}
+
+/* Fast path: inputs < CHUNK_SIZE bypass tree. Tree path: collapse stack and commit length. */
+static void finalize_state(tachyon_internal_state_t *state, uint8_t *out) {
+    if (state->stack_usage == 0 && state->buffer_len < CHUNK_SIZE) {
+        compute_kernel(state->buffer, state->buffer_len, state->domain, state->seed,
+                       state->has_key ? state->key : NULL, out);
+        free(state);
+        return;
+    }
+
+    if (state->buffer_len > 0) {
+        uint8_t chunk_hash[HASH_SIZE];
+        compute_kernel(state->buffer, state->buffer_len, DOMAIN_LEAF, state->seed,
+                       state->has_key ? state->key : NULL, chunk_hash);
+        stack_push(state, chunk_hash);
+    }
+
+    uint8_t root[HASH_SIZE];
+    int first = 1;
+
+    for (int i = 0; i < MAX_TREE_LEVELS; i++) {
+        if (state->stack_usage & (1ULL << i)) {
+            if (first) {
+                memcpy(root, &state->stack[i], HASH_SIZE);
+                first = 0;
+            } else {
+                uint8_t buffer[HASH_SIZE * 2];
+                memcpy(buffer,             &state->stack[i], HASH_SIZE);
+                memcpy(buffer + HASH_SIZE, root,             HASH_SIZE);
+                compute_kernel(buffer, HASH_SIZE * 2, DOMAIN_NODE, state->seed,
+                               state->has_key ? state->key : NULL, root);
+            }
+        }
+    }
+
+    /* Length commitment: prevents length extension attacks. */
+    uint8_t final_buf[HASH_SIZE + sizeof(uint64_t) * 2];
+    memcpy(final_buf,                   root,              HASH_SIZE);
+    memcpy(final_buf + HASH_SIZE,       &state->domain,    sizeof(uint64_t));
+    memcpy(final_buf + HASH_SIZE + 8,   &state->total_len, sizeof(uint64_t));
+    compute_kernel(final_buf, sizeof(final_buf), 0, state->seed,
+                   state->has_key ? state->key : NULL, out);
+    free(state);
+}
+
+// =============================================================================
+// PUBLIC ONE-SHOT API
+// =============================================================================
+
+int tachyon_hash_full(const uint8_t *input, size_t len, uint64_t domain,
+                      uint64_t seed, const uint8_t *key, uint8_t *out) {
+    if (!input || !out) {
+        return TACHYON_ERROR_NULL_PTR;
+    }
+
+    if (len < CHUNK_SIZE) {
+        compute_kernel(input, len, domain, seed, key, out);
+    } else {
+        tachyon_internal_state_t *s = new_state(domain, seed, key);
+        if (!s) {
+            return TACHYON_ERROR_NULL_PTR;
+        }
+        update_state(s, input, len);
+        finalize_state(s, out);
+    }
+    return 0;
+}
+
+int tachyon_hash(const uint8_t *input, size_t len, uint8_t *out) {
+    return tachyon_hash_full(input, len, 0, 0, NULL, out);
+}
+
+int tachyon_hash_seeded(const uint8_t *input, size_t len, uint64_t seed, uint8_t *out) {
+    return tachyon_hash_full(input, len, 0, seed, NULL, out);
+}
+
+int tachyon_hash_with_domain(const uint8_t *input, size_t len, uint64_t domain, uint8_t *out) {
+    return tachyon_hash_full(input, len, domain, 0, NULL, out);
+}
+
+int tachyon_hash_keyed(const uint8_t *input, size_t len, const uint8_t *key, uint8_t *out) {
+    return tachyon_hash_full(input, len, TACHYON_DOMAIN_MESSAGE_AUTH, 0, key, out);
+}
+
+// =============================================================================
+// STREAMING API
+// =============================================================================
+
+tachyon_state_t* tachyon_hasher_new(void) {
+    return (tachyon_state_t*)new_state(0, 0, NULL);
+}
+
+tachyon_state_t* tachyon_hasher_new_with_domain(uint64_t domain) {
+    return (tachyon_state_t*)new_state(domain, 0, NULL);
+}
+
+tachyon_state_t* tachyon_hasher_new_seeded(uint64_t seed) {
+    return (tachyon_state_t*)new_state(0, seed, NULL);
+}
+
+tachyon_state_t* tachyon_hasher_new_full(uint64_t domain, uint64_t seed, const uint8_t *key) {
+    return (tachyon_state_t*)new_state(domain, seed, key);
+}
+
+void tachyon_hasher_update(tachyon_state_t *state, const uint8_t *data, size_t len) {
+    update_state((tachyon_internal_state_t*)state, data, len);
+}
+
+void tachyon_hasher_finalize(tachyon_state_t *state, uint8_t *out) {
+    finalize_state((tachyon_internal_state_t*)state, out);
+}
+
+void tachyon_hasher_free(tachyon_state_t *state) {
+    if (state) {
+        free(state);
+    }
+}
+
+// =============================================================================
+// VERIFICATION HELPERS
+// =============================================================================
+
+/* Constant-time comparison. Branchless XOR fold prevents timing side-channels. */
+static int ct_eq32(const uint8_t *a, const uint8_t *b) {
+    uint8_t diff = 0;
+
+    for (int i = 0; i < HASH_SIZE; i++) {
+        diff |= a[i] ^ b[i];
+    }
+
+    return 1 - (int)((unsigned int)(diff | -diff) >> 31);
+}
+
+int tachyon_verify(const uint8_t *input, size_t len, const uint8_t *hash) {
+    if (!input || !hash) {
+        return TACHYON_ERROR_NULL_PTR;
+    }
+
+    uint8_t buf[HASH_SIZE];
+    int rc = tachyon_hash(input, len, buf);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return ct_eq32(buf, hash);
+}
+
+int tachyon_verify_mac(const uint8_t *input, size_t len, const uint8_t *key, const uint8_t *mac) {
+    if (!input || !key || !mac) {
+        return TACHYON_ERROR_NULL_PTR;
+    }
+
+    uint8_t buf[HASH_SIZE];
+    int rc = tachyon_hash_keyed(input, len, key, buf);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return ct_eq32(buf, mac);
+}
+
+/* Key derivation with domain separation. */
+int tachyon_derive_key(const char *context, size_t context_len,
+                       const uint8_t *material, uint8_t *out) {
+    if (!context || !material || !out) {
+        return TACHYON_ERROR_NULL_PTR;
+    }
+    return tachyon_hash_full((const uint8_t*)context, context_len,
+                             TACHYON_DOMAIN_KEY_DERIVATION, 0, material, out);
+}

--- a/tachyon/tachyon_impl.h
+++ b/tachyon/tachyon_impl.h
@@ -1,0 +1,227 @@
+// Tachyon
+// Copyright (c) byt3forg3
+// Licensed under the MIT or Apache 2.0 License
+// -------------------------------------------------------------------------
+
+/**
+ * @file tachyon_impl.h
+ * @brief Tachyon — Internal Implementation Details
+ *
+ * This header is NOT part of the public API. It is included only by the
+ * Tachyon C source files. Callers should include tachyon.h instead.
+ *
+ * All numeric constants (except Golden Ratio) are derived from a single rule:
+ *
+ *   constant = floor(frac(ln(p)) * 2^64)
+ *
+ * where p is a prime and frac(x) = x - floor(x).
+ *
+ * Verify (no external tools required):
+ *   python3 -c "import math; p=2; print(hex(int((math.log(p)%1)*2**64)))"
+ *   Replace p with the prime listed next to each constant.
+ *
+ * Prime assignment (consecutive, partitioned by purpose):
+ *   C0-C3, C5-C7   : ln(2, 3, 5, 7, 11, 13, 17)
+ *   WHITENING0/1   : ln(19), ln(23)
+ *   KEY_SCHEDULE_MULT: ln(29)
+ *   CLMUL_CONSTANT : ln(31)
+ *   LANE_OFFSETS   : ln(37..191) — 32 consecutive primes
+ *   C4, KEY_SCHEDULE_BASE, CHAOS_BASE: Golden Ratio (φ)
+ */
+
+#ifndef TACHYON_IMPL_H
+#define TACHYON_IMPL_H
+
+#include "tachyon.h"
+#include <stdint.h>
+#include <stddef.h>
+
+// =============================================================================
+// ROUNDS
+// =============================================================================
+
+/// 10 AES rounds for complete diffusion (standard AES-128 round count).
+#define ROUNDS 10
+
+// =============================================================================
+// STRUCTURAL CONSTANTS
+// =============================================================================
+
+/// Main block size for full compression (in bytes).
+#define BLOCK_SIZE 512
+
+/// Remainder chunk size for finalization (in bytes).
+#define REMAINDER_CHUNK_SIZE 64
+
+/// Number of parallel lanes in the state.
+#define NUM_LANES 8
+
+/// Elements per lane (128-bit vectors).
+#define LANE_STRIDE 4
+
+/// Total state size in bytes (32 × 16-byte vectors).
+#define STATE_SIZE 512
+
+/// Size of a single 128-bit vector in bytes.
+#define VEC_SIZE 16
+
+/// AES GF(2^8) reduction polynomial: x^8 + x^4 + x^3 + x + 1
+#define GF_POLY 0x1b
+
+/// Hash output size in bytes (256-bit digest).
+#define HASH_SIZE 32
+
+// =============================================================================
+// INDEX ARITHMETIC MACROS
+// =============================================================================
+
+/// Compute flat index into acc[32] from lane and element indices.
+/// Treats acc[32] as an 8-lane × 4-element matrix: acc[lane*4 + elem].
+#define ACC_INDEX(lane, elem) ((lane) * LANE_STRIDE + (elem))
+
+/// Compute data array index from lane and element (8×4 layout).
+#define DATA_INDEX(lane, elem) ((lane) * LANE_STRIDE + (elem))
+
+// =============================================================================
+// GOLDEN RATIO
+// =============================================================================
+
+/// φ (Golden Ratio) in 64-bit fixed-point: floor(2^64 / φ).
+/// Used wherever a canonical nothing-up-my-sleeve constant is needed
+#define GOLDEN_RATIO  0x9E3779B97F4A7C15ULL
+
+// =============================================================================
+// INITIALIZATION CONSTANTS — frac(ln(p)) for consecutive primes
+// =============================================================================
+
+#define C0 0xB17217F7D1CF79ABULL // ln(2)
+#define C1 0x193EA7AAD030A976ULL // ln(3)
+#define C2 0x9C041F7ED8D336AFULL // ln(5)
+#define C3 0xF2272AE325A57546ULL // ln(7)
+#define C4 GOLDEN_RATIO          // φ — Golden Ratio (no prime equivalent)
+#define C5 0x65DC76EFE6E976F7ULL // ln(11)
+#define C6 0x90A08566318A1FD0ULL // ln(13)
+#define C7 0xD54D783F4FEF39DFULL // ln(17)
+
+// =============================================================================
+// KEY SCHEDULE
+// =============================================================================
+
+/// Starting value for the AESENC-derived round key chain.
+#define KEY_SCHEDULE_BASE GOLDEN_RATIO
+/// Per-round diversification multiplier: frac(ln(29)).
+#define KEY_SCHEDULE_MULT 0x5E071979BFC3D7ACULL // ln(29)
+
+// =============================================================================
+// LANE OFFSETS — frac(ln(p)) for primes 37..191
+// =============================================================================
+//
+// Per-lane tweaks that break symmetry across the 8 parallel AES lanes.
+// 32 unique offsets for full track diversification.
+
+static const uint64_t LANE_OFFSETS[32] = {
+    0x9C651DC758F7A6F2ULL, // ln(37)
+    0xB6ACA8B1D589B575ULL, // ln(41)
+    0xC2DE02C29D8222CBULL, // ln(43)
+    0xD9A345F21E16CB31ULL, // ln(47)
+    0xF8650D044795568FULL, // ln(53)
+    0x13D97E71CA5E2DA9ULL, // ln(59)
+    0x1C623AC49B03386CULL, // ln(61)
+    0x3466BC4A044B5829ULL, // ln(67)
+    0x433EFD0935B23D6BULL, // ln(71)
+    0x4A5B8CC88BF98CD3ULL, // ln(73)
+    0x5E94226BEC5CBFB8ULL, // ln(79)
+    0x6B392358B9206784ULL, // ln(83)
+    0x7D1745EBA2BD8E2DULL, // ln(89)
+    0x9320423952FE003BULL, // ln(97)
+    0x9D7889C6EE8C2F8EULL, // ln(101)
+    0xA27D995644FAF994ULL, // ln(103)
+    0xAC3E82AFD1D6DC79ULL, // ln(107)
+    0xB0FC2CC0554191F5ULL, // ln(109)
+    0xBA36168CE0D6EE1DULL, // ln(113)
+    0xD81CA5180B90858DULL, // ln(127)
+    0xE00CEE88B2189A5CULL, // ln(131)
+    0xEB83DEB56027349AULL, // ln(137)
+    0xEF39AF05C2C4931BULL, // ln(139)
+    0x0102A006F9CB3C2AULL, // ln(149)
+    0x046C738E0014C2F8ULL, // ln(151)
+    0x0E662006821719E4ULL, // ln(157)
+    0x1800035E755EC056ULL, // ln(163)
+    0x1E34D7AD75D7A815ULL, // ln(167)
+    0x273E1E311EA1A70BULL, // ln(173)
+    0x2FF88423D2160504ULL, // ln(179)
+    0x32D0B391A3CAA870ULL, // ln(181)
+    0x4094FDCB1C2E7EE1ULL  // ln(191)
+};
+
+// =============================================================================
+// FINALIZATION
+// =============================================================================
+
+/// Chaos injection constant for entropy in sparse inputs.
+#define CHAOS_BASE GOLDEN_RATIO
+
+/// Carry-less multiplication constant: frac(ln(31)).
+/// Polynomial coefficient in GF(2^128).
+#define CLMUL_CONSTANT  0x6F19C912256B3E22ULL // ln(31)
+
+/// Second CLMUL constant for polynomial differentiation: frac(ln(193)).
+#define CLMUL_CONSTANT2 0x433FAA0A53988000ULL  // ln(193)
+
+/// Pre-whitening constants: frac(ln(19)) and frac(ln(23)).
+#define WHITENING0 0xF1C6C0C096658E40ULL // ln(19)
+#define WHITENING1 0x22AFBFBA367E0122ULL // ln(23)
+
+// Merkle tree node type tags (XORed into domain field to distinguish leaf/node)
+#define DOMAIN_LEAF 0xFFFFFFFF00000000ULL
+#define DOMAIN_NODE 0xFFFFFFFF00000001ULL
+
+// =============================================================================
+// SHORT PATH PRECOMPUTED STATE
+// =============================================================================
+//
+// Precomputed post-merge state for seed=0, key=None.
+// Recompute: run tachyon_portable.c with seed=0, key=None and print acc[] after linear_init().
+// Values are stable across all conforming implementations.
+
+static const uint64_t SHORT_INIT[4][2] = {
+    {0x8572268C3E8B949AULL, 0x55260EB0F6D08B28ULL},
+    {0x7B6B869404C510F3ULL, 0x58153672FF7257BBULL},
+    {0x23AE5234151A861EULL, 0x436D91128FA3A475ULL},
+    {0x2D3EA94F6D07F7BCULL, 0x31C028B304D23746ULL}
+};
+
+// =============================================================================
+// PRECOMPUTED ROUND KEY CHAIN
+// =============================================================================
+//
+// AESENC-derived round key schedule for the 10-round key expansion.
+// Recompute: initialize acc[0] = {GOLDEN_RATIO, GOLDEN_RATIO} and apply
+// aesenc_s() ten times, reading out the 128-bit result after each round.
+// See tachyon_portable.c for the portable aesenc_s() implementation.
+
+static const uint64_t RK_CHAIN[10][2] = {
+    {0x9E3779B97F4A7C15ULL, 0xFBEB0F5699A30AE2ULL},
+    {0xE0772D418B604247ULL, 0xCB99FBAD212715AAULL},
+    {0x9943E41C900EA2BDULL, 0x3391839B4E1DB7D2ULL},
+    {0x3FDD17D01F01E973ULL, 0x4FE62D4E63CB7DB7ULL},
+    {0x7C5B681836BF20E5ULL, 0x20EA7205089674B4ULL},
+    {0x57E52B0B6FD122C4ULL, 0x92E23D97BDB01EABULL},
+    {0x9E667CEF92177102ULL, 0x1A1761F6D1C3AAA5ULL},
+    {0x5976F92D468FE2FDULL, 0xAE3623405BAFD085ULL},
+    {0xCD2AF6F6F29BF341ULL, 0xD310BEDDA16B12D4ULL},
+    {0xD11A12CCD34BBD1BULL, 0xAC09BEFD5925A5FEULL}
+};
+
+// =============================================================================
+// BACKEND KERNEL PROTOTYPES
+// =============================================================================
+//
+// Three hardware-specific implementations selected at runtime by the
+// dispatcher in tachyon_dispatcher.c via CPUID.
+
+void tachyon_avx512_oneshot (const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out);
+void tachyon_aesni_oneshot  (const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out);
+void tachyon_portable_oneshot(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out);
+
+#endif // TACHYON_IMPL_H

--- a/tachyon/tachyon_portable.c
+++ b/tachyon/tachyon_portable.c
@@ -1,0 +1,651 @@
+// Tachyon
+// Copyright (c) byt3forg3
+// Licensed under the MIT or Apache 2.0 License
+// -------------------------------------------------------------------------
+
+#include "tachyon.h"
+#include "tachyon_impl.h"
+#include <string.h>
+
+// =============================================================================
+// PORTABLE KERNEL (PURE C)
+// =============================================================================
+
+
+typedef struct { uint8_t b[VEC_SIZE]; } tachyon_vec128_t;
+
+struct portable_state_t {
+    tachyon_vec128_t acc[32];
+    uint64_t total_len;
+    uint64_t domain;
+    uint64_t seed;
+    uint8_t key[HASH_SIZE];
+    int has_key;
+};
+
+// AES S-Box
+static const uint8_t SBOX[256] = {
+    0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+    0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+    0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+    0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+    0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+    0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+    0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+    0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+    0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+    0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+    0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+    0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+    0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+    0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+    0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+    0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16
+};
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/* Pack two uint64 values into a 128-bit register (lo in bytes 0-7, hi in bytes 8-15). */
+static inline tachyon_vec128_t to_m128i(uint64_t lo, uint64_t hi) {
+    tachyon_vec128_t r; memcpy(&r.b[0], &lo, 8); memcpy(&r.b[8], &hi, 8); return r;
+}
+
+static inline void load_u64(const uint8_t *ptr, uint64_t *out) { memcpy(out, ptr, 8); }
+static inline void store_u64(uint8_t *ptr, uint64_t val) { memcpy(ptr, &val, 8); }
+
+static inline tachyon_vec128_t xor_m128i(tachyon_vec128_t a, tachyon_vec128_t b) {
+    tachyon_vec128_t r; for (int i = 0; i < VEC_SIZE; i++) r.b[i] = a.b[i] ^ b.b[i]; return r;
+}
+
+static inline tachyon_vec128_t add_epi64(tachyon_vec128_t a, tachyon_vec128_t b) {
+    tachyon_vec128_t r; uint64_t a0, a1, b0, b1;
+    load_u64(&a.b[0], &a0); load_u64(&a.b[8], &a1);
+    load_u64(&b.b[0], &b0); load_u64(&b.b[8], &b1);
+    store_u64(&r.b[0], a0 + b0); store_u64(&r.b[8], a1 + b1); return r;
+}
+
+static inline uint8_t gf_double(uint8_t b) {
+    return (uint8_t)((b << 1) ^ ((b >> 7) * GF_POLY)); // AES GF(2^8): x^8 + x^4 + x^3 + x + 1
+}
+
+static void mix_column(uint8_t *c) {
+    uint8_t t[4] = {c[0], c[1], c[2], c[3]};
+    c[0] = gf_double(t[0] ^ t[1]) ^ t[1] ^ t[2] ^ t[3];
+    c[1] = gf_double(t[1] ^ t[2]) ^ t[2] ^ t[3] ^ t[0];
+    c[2] = gf_double(t[2] ^ t[3]) ^ t[3] ^ t[0] ^ t[1];
+    c[3] = gf_double(t[3] ^ t[0]) ^ t[0] ^ t[1] ^ t[2];
+}
+
+static tachyon_vec128_t aesenc_s(tachyon_vec128_t state, tachyon_vec128_t key) {
+    uint8_t s[VEC_SIZE];
+    s[0] = state.b[0];   s[4] = state.b[4];   s[8] = state.b[8];   s[12] = state.b[12];
+    s[1] = state.b[5];   s[5] = state.b[9];   s[9] = state.b[13];  s[13] = state.b[1];
+    s[2] = state.b[10];  s[6] = state.b[14];  s[10] = state.b[2];  s[14] = state.b[6];
+    s[3] = state.b[15];  s[7] = state.b[3];   s[11] = state.b[7];  s[15] = state.b[11];
+    for (int i = 0; i < VEC_SIZE; i++) s[i] = SBOX[s[i]];
+    mix_column(&s[0]); mix_column(&s[4]); mix_column(&s[8]); mix_column(&s[12]);
+    
+    tachyon_vec128_t res; for (int i = 0; i < VEC_SIZE; i++) res.b[i] = (uint8_t)(s[i] ^ key.b[i]);
+    return res;
+}
+
+static void clmul_u64_s(uint64_t a, uint64_t b, uint64_t *r_lo, uint64_t *r_hi) {
+    uint64_t hi = 0, lo = 0;
+    for (int i = 0; i < 64; i++) {
+        /* Branchless: mask is all-ones if bit i of b is set, zero otherwise.
+         * Avoids a data-dependent branch that could leak information via timing. */
+        uint64_t mask = -(uint64_t)((b >> i) & 1);
+        lo ^= (a << i) & mask;
+        hi ^= ((i == 0) ? 0 : (a >> (64 - i))) & mask; /* i==0 guard: loop counter, not data */
+    }
+    *r_lo = lo; *r_hi = hi;
+}
+
+static tachyon_vec128_t clmulepi64_s(tachyon_vec128_t a, tachyon_vec128_t b, int imm) {
+    uint64_t a_val, b_val, lo, hi;
+    load_u64(&a.b[(imm & 0x01) ? 8 : 0], &a_val);
+    load_u64(&b.b[(imm & 0x10) ? 8 : 0], &b_val);
+    clmul_u64_s(a_val, b_val, &lo, &hi); return to_m128i(lo, hi);
+}
+
+// =============================================================================
+// LOGIC
+// =============================================================================
+
+static void linear_init(struct portable_state_t *s) {
+    const uint64_t c_vals[NUM_LANES] = {C0, C1, C2, C3, C4, C5, C6, C7};
+    for (int i = 0; i < 32; i++) {
+        uint64_t base = c_vals[i / LANE_STRIDE];
+        uint64_t offset = (uint64_t)(i % LANE_STRIDE) * 2;
+        s->acc[i] = to_m128i(base + offset, base + offset + 1);
+    }
+    uint64_t seed_val = s->seed ? s->seed : C5;
+    tachyon_vec128_t seed_vec = to_m128i(seed_val, seed_val);
+    for (int i = 0; i < 32; i++) {
+        s->acc[i] = aesenc_s(s->acc[i], seed_vec);
+    }
+
+    if (s->has_key) {
+        tachyon_vec128_t k0, k1;
+        memcpy(k0.b, &s->key[0], VEC_SIZE);
+        memcpy(k1.b, &s->key[VEC_SIZE], VEC_SIZE);
+        tachyon_vec128_t gr = to_m128i(GOLDEN_RATIO, GOLDEN_RATIO);
+        tachyon_vec128_t keys[LANE_STRIDE] = {k0, k1, xor_m128i(k0, gr), xor_m128i(k1, gr)};
+        for (int i = 0; i < NUM_LANES; i++) {
+            tachyon_vec128_t lo = to_m128i(LANE_OFFSETS[i], LANE_OFFSETS[i]);
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                int idx = ACC_INDEX(i, j);
+                s->acc[idx] = aesenc_s(s->acc[idx], add_epi64(keys[j], lo));
+                s->acc[idx] = aesenc_s(s->acc[idx], keys[j]);
+            }
+        }
+    }
+}
+
+/* Phase 1: Round-Robin Mix (first 5 rounds with lane rotation). */
+static void compress_phase1_roundrobin(struct portable_state_t *s, tachyon_vec128_t d[NUM_LANES][LANE_STRIDE],
+                                       const tachyon_vec128_t rk_base[ROUNDS], const tachyon_vec128_t lo_all[32],
+                                       tachyon_vec128_t blk) {
+    for (int r = 0; r < 5; r++) {
+        tachyon_vec128_t rk = rk_base[r];
+        for (int i = 0; i < 32; i++) {
+            s->acc[i] = aesenc_s(s->acc[i], add_epi64(d[i / LANE_STRIDE][i % LANE_STRIDE], add_epi64(rk, add_epi64(lo_all[i], blk))));
+        }
+        for (int i = 0; i < NUM_LANES; i++) {
+            int src = (i + 3) % NUM_LANES;  // Feedback from lane i+3 (mod 8) for diffusion
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                d[i][j] = xor_m128i(d[i][j], s->acc[ACC_INDEX(src, j)]);
+            }
+        }
+        tachyon_vec128_t old[32];
+        memcpy(old, s->acc, STATE_SIZE);
+
+        for (int i = 0; i < NUM_LANES; i++) {
+            memcpy(&s->acc[ACC_INDEX(i, 0)], &old[ACC_INDEX((i + 1) % NUM_LANES, 0)], LANE_STRIDE * VEC_SIZE);
+        }
+    }
+}
+
+/* Mid-block mixing: break lane symmetry with element rotation and XOR/ADD mixing. */
+static void compress_midblock_mixing(struct portable_state_t *s) {
+    // Treating acc[32] as 8-lane × 4-element matrix: acc[lane*4 + elem]
+    tachyon_vec128_t old_m[32];
+    memcpy(old_m, s->acc, STATE_SIZE);
+
+    for (int i = 0; i < NUM_LANES; i++) {
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            s->acc[ACC_INDEX(i, j)] = old_m[ACC_INDEX(i, (j + 1) % LANE_STRIDE)];
+        }
+    }
+    for (int lane_offset = 0; lane_offset < LANE_STRIDE; lane_offset++) {
+        for (int i = 0; i < 4; i++) {
+            tachyon_vec128_t t_lo = s->acc[ACC_INDEX(i, lane_offset)];
+            tachyon_vec128_t t_hi = s->acc[ACC_INDEX(i + 4, lane_offset)];
+            s->acc[ACC_INDEX(i, lane_offset)]     = xor_m128i(t_lo, t_hi);
+            s->acc[ACC_INDEX(i + 4, lane_offset)] = add_epi64(t_hi, t_lo);
+        }
+    }
+    for (int lane_offset = 0; lane_offset < LANE_STRIDE; lane_offset++) {
+        tachyon_vec128_t a0 = s->acc[ACC_INDEX(0, lane_offset)], a2 = s->acc[ACC_INDEX(2, lane_offset)];
+        s->acc[ACC_INDEX(0, lane_offset)] = xor_m128i(a0, a2);
+        s->acc[ACC_INDEX(2, lane_offset)] = add_epi64(a2, a0);
+
+        tachyon_vec128_t a1 = s->acc[ACC_INDEX(1, lane_offset)], a3 = s->acc[ACC_INDEX(3, lane_offset)];
+        s->acc[ACC_INDEX(1, lane_offset)] = xor_m128i(a1, a3);
+        s->acc[ACC_INDEX(3, lane_offset)] = add_epi64(a3, a1);
+
+        tachyon_vec128_t a4 = s->acc[ACC_INDEX(4, lane_offset)], a6 = s->acc[ACC_INDEX(6, lane_offset)];
+        s->acc[ACC_INDEX(4, lane_offset)] = xor_m128i(a4, a6);
+        s->acc[ACC_INDEX(6, lane_offset)] = add_epi64(a6, a4);
+
+        tachyon_vec128_t a5 = s->acc[ACC_INDEX(5, lane_offset)], a7 = s->acc[ACC_INDEX(7, lane_offset)];
+        s->acc[ACC_INDEX(5, lane_offset)] = xor_m128i(a5, a7);
+        s->acc[ACC_INDEX(7, lane_offset)] = add_epi64(a7, a5);
+    }
+}
+
+/* Phase 2: Completion rounds (5-9) with shifted data index and Davies-Meyer feed-forward. */
+static void compress_phase2_and_feedforward(struct portable_state_t *s, tachyon_vec128_t d[NUM_LANES][LANE_STRIDE],
+                                            const tachyon_vec128_t rk_base[ROUNDS], const tachyon_vec128_t lo_all[32],
+                                            tachyon_vec128_t blk, const tachyon_vec128_t saves[32]) {
+    for (int r = 5; r < ROUNDS; r++) {
+        tachyon_vec128_t rk = rk_base[r];
+        for (int i = 0; i < 32; i++) {
+            s->acc[i] = aesenc_s(s->acc[i], add_epi64(d[(i / LANE_STRIDE + 4) % NUM_LANES][i % LANE_STRIDE], add_epi64(rk, add_epi64(lo_all[i], blk))));
+        }
+        for (int i = 0; i < NUM_LANES; i++) {
+            int src = (i + 3) % NUM_LANES;  // Feedback from lane i+3 (mod 8) for diffusion
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                d[i][j] = xor_m128i(d[i][j], s->acc[ACC_INDEX(src, j)]);
+            }
+        }
+        tachyon_vec128_t old[32];
+        memcpy(old, s->acc, STATE_SIZE);
+        for (int i = 0; i < NUM_LANES; i++) {
+            memcpy(&s->acc[ACC_INDEX(i, 0)], &old[ACC_INDEX((i + 1) % NUM_LANES, 0)], LANE_STRIDE * VEC_SIZE);
+        }
+    }
+
+    // Davies-Meyer Feed-Forward
+    tachyon_vec128_t old_f[32];
+    memcpy(old_f, s->acc, STATE_SIZE);
+    for (int i = 0; i < NUM_LANES; i++) {
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            s->acc[ACC_INDEX(i, j)] = old_f[ACC_INDEX(i, (j + 1) % LANE_STRIDE)];
+        }
+    }
+    for (int i = 0; i < 32; i++) {
+        s->acc[i] = xor_m128i(s->acc[i], saves[i]);
+    }
+}
+
+static void linear_compress(struct portable_state_t *s, const uint8_t *data, uint64_t block_idx) {
+    tachyon_vec128_t blk = to_m128i(block_idx, block_idx);
+    tachyon_vec128_t wk  = to_m128i(WHITENING0, WHITENING1);
+
+    tachyon_vec128_t rk_base[ROUNDS];
+    for (int i = 0; i < ROUNDS; i++) {
+        rk_base[i] = to_m128i(RK_CHAIN[i][0], RK_CHAIN[i][1]);
+    }
+
+    tachyon_vec128_t lo_all[32];
+    for (int i = 0; i < 32; i++) {
+        lo_all[i] = to_m128i(LANE_OFFSETS[i], LANE_OFFSETS[i]);
+    }
+
+    /* Davies-Meyer feed-forward: save state before compression. */
+    tachyon_vec128_t saves[32];
+    memcpy(saves, s->acc, STATE_SIZE);
+
+    tachyon_vec128_t d[NUM_LANES][LANE_STRIDE];
+    for (int i = 0; i < NUM_LANES; i++) {
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            tachyon_vec128_t val;
+            memcpy(val.b, data + DATA_INDEX(i, j) * VEC_SIZE, VEC_SIZE);
+            d[i][j] = aesenc_s(val, wk);
+        }
+    }
+
+    compress_phase1_roundrobin(s, d, rk_base, lo_all, blk);
+    compress_midblock_mixing(s);
+    compress_phase2_and_feedforward(s, d, rk_base, lo_all, blk, saves);
+}
+
+/* Process remainder chunks (< BLOCK_SIZE bytes, in REMAINDER_CHUNK_SIZE-byte increments). */
+static size_t finalize_remainder_chunks(struct portable_state_t *s, const uint8_t *remainder, size_t rem_len,
+                                        tachyon_vec128_t wk, const tachyon_vec128_t rk_chain[ROUNDS]) {
+    size_t off = 0;
+    int chunk_idx = 0;
+
+    while (rem_len - off >= REMAINDER_CHUNK_SIZE) {
+        const uint8_t *ptr = remainder + off;
+        tachyon_vec128_t d_rem[LANE_STRIDE];
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            tachyon_vec128_t val;
+            memcpy(val.b, ptr + j * VEC_SIZE, VEC_SIZE);
+            d_rem[j] = aesenc_s(val, wk);
+        }
+        int base = chunk_idx * LANE_STRIDE;
+        tachyon_vec128_t saves[LANE_STRIDE];
+        memcpy(saves, &s->acc[base], LANE_STRIDE * VEC_SIZE);
+        for (int r = 0; r < ROUNDS; r++) {
+            tachyon_vec128_t rk = rk_chain[r];
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                s->acc[base + j] = aesenc_s(s->acc[base + j], add_epi64(d_rem[j], add_epi64(rk, to_m128i(LANE_OFFSETS[base + j], LANE_OFFSETS[base + j]))));
+            }
+            tachyon_vec128_t t0 = s->acc[base], t1 = s->acc[base + 1], t2 = s->acc[base + 2], t3 = s->acc[base + 3];
+            d_rem[0] = xor_m128i(d_rem[0], t1);
+            d_rem[1] = xor_m128i(d_rem[1], t2);
+            d_rem[2] = xor_m128i(d_rem[2], t3);
+            d_rem[3] = xor_m128i(d_rem[3], t0);
+            s->acc[base] = t1;
+            s->acc[base + 1] = t2;
+            s->acc[base + 2] = t3;
+            s->acc[base + 3] = t0;
+        }
+        for (int j = 0; j < LANE_STRIDE; j++) {
+            s->acc[base + j] = xor_m128i(s->acc[base + j], saves[j]);
+        }
+        off += REMAINDER_CHUNK_SIZE;
+        chunk_idx++;
+    }
+
+    return off;
+}
+
+/* Three-level tree merge: 32 → 16 → 8 → 4 lanes. */
+static void finalize_tree_merge(struct portable_state_t *s) {
+    tachyon_vec128_t mrk0 = to_m128i(C5, C5), mrk1 = to_m128i(C6, C6), mrk2 = to_m128i(C7, C7);
+
+    // Level 0: 32 -> 16
+    for (int i = 0; i < 16; i++) {
+        s->acc[i] = aesenc_s(s->acc[i], xor_m128i(s->acc[i + 16], mrk0));
+        s->acc[i] = aesenc_s(s->acc[i], xor_m128i(s->acc[i], mrk0));
+    }
+    // Level 1: 16 -> 8
+    for (int i = 0; i < 8; i++) {
+        s->acc[i] = aesenc_s(s->acc[i], xor_m128i(s->acc[i + 8], mrk1));
+        s->acc[i] = aesenc_s(s->acc[i], xor_m128i(s->acc[i], mrk1));
+    }
+    // Level 2: 8 -> 4
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        s->acc[i] = aesenc_s(s->acc[i], xor_m128i(s->acc[i + LANE_STRIDE], mrk2));
+        s->acc[i] = aesenc_s(s->acc[i], xor_m128i(s->acc[i], mrk2));
+    }
+}
+
+/* Quadratic CLMUL hardening: polynomial mixing to eliminate linear shortcuts. */
+static void finalize_clmul_hardening(struct portable_state_t *s) {
+    tachyon_vec128_t clmul_k = to_m128i(CLMUL_CONSTANT, CLMUL_CONSTANT2);
+    for(int i = 0; i < LANE_STRIDE; i++) {
+        // Round 1: polynomial mixing in GF(2)[x]
+        tachyon_vec128_t cl1 = xor_m128i(clmulepi64_s(s->acc[i], clmul_k, 0x00), clmulepi64_s(s->acc[i], clmul_k, 0x11));
+        // AES barrier: polynomial product as round key (degree ~254)
+        tachyon_vec128_t mid = aesenc_s(s->acc[i], cl1);
+        // Round 2: self-multiply lo×hi → quadratic in GF(2)[x] (degree ~254²)
+        tachyon_vec128_t cl2 = clmulepi64_s(mid, mid, 0x01);
+        // Nonlinear fold: aesenc eliminates linear shortcut back to original state
+        s->acc[i] = aesenc_s(s->acc[i], xor_m128i(cl1, cl2));
+    }
+}
+
+/* Final block processing: inject length/domain and perform AES rounds. */
+static void finalize_block_process(struct portable_state_t *s, tachyon_vec128_t d_pad[LANE_STRIDE],
+                                   uint64_t total_len, const tachyon_vec128_t rk_chain[ROUNDS]) {
+    tachyon_vec128_t save_final[LANE_STRIDE];
+    tachyon_vec128_t meta[LANE_STRIDE];
+    for (int j = 0; j < LANE_STRIDE; j++) {
+        save_final[j] = s->acc[j];
+    }
+    meta[0] = to_m128i(s->domain ^ total_len, CHAOS_BASE);
+    meta[1] = to_m128i(total_len, s->domain);
+    meta[2] = to_m128i(CHAOS_BASE, total_len);
+    meta[3] = to_m128i(s->domain, CHAOS_BASE);
+
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        s->acc[i] = xor_m128i(xor_m128i(s->acc[i], d_pad[i]), meta[i]);
+    }
+    for (int r = 0; r < ROUNDS; r++) {
+        tachyon_vec128_t rk = rk_chain[r];
+        for (int i = 0; i < LANE_STRIDE; i++) {
+            s->acc[i] = aesenc_s(s->acc[i], add_epi64(d_pad[i], rk));
+        }
+        // Unconditional Lane Rotation (Matches valignq/alignr behavior)
+        tachyon_vec128_t tmp = s->acc[0];
+        s->acc[0] = s->acc[1];
+        s->acc[1] = s->acc[2];
+        s->acc[2] = s->acc[3];
+        s->acc[3] = tmp;
+
+        if (r % 2 == 1) {
+            d_pad[0] = xor_m128i(d_pad[0], s->acc[0]);
+            d_pad[1] = xor_m128i(d_pad[1], s->acc[1]);
+            d_pad[2] = xor_m128i(d_pad[2], s->acc[2]);
+            d_pad[3] = xor_m128i(d_pad[3], s->acc[3]);
+        }
+    }
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        s->acc[i] = xor_m128i(s->acc[i], save_final[i]);
+    }
+}
+
+/* Lane reduction helper (shared between short and finalize paths). */
+static void lane_reduction_4to256(tachyon_vec128_t acc[LANE_STRIDE], uint8_t *out) {
+    tachyon_vec128_t mrk0 = to_m128i(C5, C5), mrk1 = to_m128i(C6, C6), mrk2 = to_m128i(C7, C7);
+
+    tachyon_vec128_t a[LANE_STRIDE];
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        a[i] = aesenc_s(acc[i], acc[i]);
+    }
+
+    // Round 1: distant swap (0<->2, 1<->3)
+    tachyon_vec128_t b[LANE_STRIDE];
+    b[0] = aesenc_s(a[0], a[2]);
+    b[1] = aesenc_s(a[1], a[3]);
+    b[2] = aesenc_s(a[2], a[0]);
+    b[3] = aesenc_s(a[3], a[1]);
+
+    // Round 2: adjacent swap (0<->1, 2<->3) + per-lane asymmetry constants
+    tachyon_vec128_t zero = to_m128i(0, 0);
+    tachyon_vec128_t c[LANE_STRIDE];
+    c[0] = aesenc_s(b[0], xor_m128i(b[1], zero)); /* lane 0: no constant  */
+    c[1] = aesenc_s(b[1], xor_m128i(b[0], mrk2)); /* lane 1: C7           */
+    c[2] = aesenc_s(b[2], xor_m128i(b[3], mrk1)); /* lane 2: C6           */
+    c[3] = aesenc_s(b[3], xor_m128i(b[2], mrk0)); /* lane 3: C5           */
+
+    // Round 3: distant swap again
+    tachyon_vec128_t fd[LANE_STRIDE];
+    fd[0] = aesenc_s(c[0], c[2]);
+    fd[1] = aesenc_s(c[1], c[3]);
+    fd[2] = aesenc_s(c[2], c[0]);
+    fd[3] = aesenc_s(c[3], c[1]);
+
+    // Round 4: adjacent swap + asymmetry again
+    tachyon_vec128_t e[LANE_STRIDE];
+    e[0] = aesenc_s(fd[0], xor_m128i(fd[1], zero));
+    e[1] = aesenc_s(fd[1], xor_m128i(fd[0], mrk2));
+    e[2] = aesenc_s(fd[2], xor_m128i(fd[3], mrk1));
+    e[3] = aesenc_s(fd[3], xor_m128i(fd[2], mrk0));
+
+    // Output: first two lanes = 256 bits
+    memcpy(out,      e[0].b, VEC_SIZE);
+    memcpy(out + VEC_SIZE, e[1].b, VEC_SIZE);
+}
+
+/* Re-absorb keying material if present (keyed mode only). */
+static void finalize_key_reabsorption(struct portable_state_t *s) {
+    if (!s->has_key) return;
+
+    tachyon_vec128_t k0, k1;
+    memcpy(k0.b, s->key, VEC_SIZE);
+    memcpy(k1.b, s->key + VEC_SIZE, VEC_SIZE);
+
+    // Round 1
+    s->acc[0] = aesenc_s(s->acc[0], k0);
+    s->acc[1] = aesenc_s(s->acc[1], k1);
+    s->acc[2] = aesenc_s(s->acc[2], k1);
+    s->acc[3] = aesenc_s(s->acc[3], k0);
+    // Round 2
+    s->acc[0] = aesenc_s(s->acc[0], k1);
+    s->acc[1] = aesenc_s(s->acc[1], k0);
+    s->acc[2] = aesenc_s(s->acc[2], k0);
+    s->acc[3] = aesenc_s(s->acc[3], k1);
+    // Round 3
+    s->acc[0] = aesenc_s(s->acc[0], k0);
+    s->acc[1] = aesenc_s(s->acc[1], k1);
+    s->acc[2] = aesenc_s(s->acc[2], k0);
+    s->acc[3] = aesenc_s(s->acc[3], k1);
+    // Round 4
+    s->acc[0] = aesenc_s(s->acc[0], k0);
+    s->acc[1] = aesenc_s(s->acc[1], k0);
+    s->acc[2] = aesenc_s(s->acc[2], k1);
+    s->acc[3] = aesenc_s(s->acc[3], k1);
+}
+
+/* Final lane reduction: 4 lanes → 256-bit output via AES permutation cascade. */
+static void finalize_lane_reduction(struct portable_state_t *s, uint8_t *out) {
+    lane_reduction_4to256(s->acc, out);
+}
+
+static void linear_finalize(struct portable_state_t *s, const uint8_t *remainder, size_t rem_len, uint64_t total_len, uint8_t *out) {
+    tachyon_vec128_t wk = to_m128i(WHITENING0, WHITENING1);
+    tachyon_vec128_t rk_chain[ROUNDS];
+    for (int i = 0; i < ROUNDS; i++) {
+        rk_chain[i] = to_m128i(RK_CHAIN[i][0], RK_CHAIN[i][1]);
+    }
+
+    // 1. Process remainder chunks (< BLOCK_SIZE bytes, in REMAINDER_CHUNK_SIZE-byte increments)
+    size_t off = finalize_remainder_chunks(s, remainder, rem_len, wk, rk_chain);
+
+    // 2. Prepare final padding block
+    uint8_t blk_pad[REMAINDER_CHUNK_SIZE] = {0};
+    if (rem_len > off) {
+        memcpy(blk_pad, remainder + off, rem_len - off);
+    }
+    blk_pad[rem_len - off] = 0x80;  // Merkle-Damgård padding sentinel
+
+    tachyon_vec128_t d_pad[LANE_STRIDE];
+    for (int j = 0; j < LANE_STRIDE; j++) {
+        tachyon_vec128_t val;
+        memcpy(val.b, blk_pad + j * VEC_SIZE, VEC_SIZE);
+        d_pad[j] = aesenc_s(val, wk);
+    }
+
+    // 3. Tree merge: 32 → 16 → 8 → 4 lanes
+    finalize_tree_merge(s);
+
+    // 4. Quadratic CLMUL hardening
+    finalize_clmul_hardening(s);
+
+    // 5. Final block processing (inject length/domain)
+    finalize_block_process(s, d_pad, total_len, rk_chain);
+
+    // 6. Key re-absorption (keyed mode only)
+    finalize_key_reabsorption(s);
+
+    // 7. Final lane reduction: 4 lanes → 256-bit output
+    finalize_lane_reduction(s, out);
+}
+
+/* Initialize short-path state (seed + optional key absorption). */
+static void short_initialize_state(tachyon_vec128_t acc[LANE_STRIDE], uint64_t seed, const uint8_t *key) {
+    if (seed == 0 && !key) {
+        for (int i = 0; i < LANE_STRIDE; i++) {
+            acc[i] = to_m128i(SHORT_INIT[i][0], SHORT_INIT[i][1]);
+        }
+    } else {
+        uint64_t base = C0;
+
+        for (int i = 0; i < LANE_STRIDE; i++) {
+            acc[i] = to_m128i(base + (uint64_t)i * 2, base + (uint64_t)i * 2 + 1);
+        }
+
+        uint64_t seed_val = (seed != 0) ? seed : C5;
+        tachyon_vec128_t s_vec = to_m128i(seed_val, seed_val);
+
+        for (int i = 0; i < LANE_STRIDE; i++) {
+            acc[i] = aesenc_s(acc[i], s_vec);
+        }
+
+        if (key) {
+            tachyon_vec128_t k0, k1;
+            memcpy(k0.b, key, VEC_SIZE);
+            memcpy(k1.b, key + VEC_SIZE, VEC_SIZE);
+
+            tachyon_vec128_t gr = to_m128i(GOLDEN_RATIO, GOLDEN_RATIO);
+            tachyon_vec128_t keys[LANE_STRIDE] = {
+                k0,
+                k1,
+                xor_m128i(k0, gr),
+                xor_m128i(k1, gr)
+            };
+
+            tachyon_vec128_t lo = to_m128i(LANE_OFFSETS[0], LANE_OFFSETS[0]);
+
+            for (int j = 0; j < LANE_STRIDE; j++) {
+                 acc[j] = aesenc_s(acc[j], add_epi64(keys[j], lo));
+                 acc[j] = aesenc_s(acc[j], keys[j]);
+            }
+        }
+    }
+}
+
+/* Process single block with Davies-Meyer construction. */
+static void short_process_block(tachyon_vec128_t acc[LANE_STRIDE], const uint8_t *input, size_t len, uint64_t domain) {
+    /* Pre-whiten data block and set up padding. */
+    tachyon_vec128_t wk = to_m128i(WHITENING0, WHITENING1);
+    tachyon_vec128_t d[LANE_STRIDE];
+    uint8_t blk[REMAINDER_CHUNK_SIZE] = {0};
+
+    if (len > 0) {
+        memcpy(blk, input, len);
+    }
+    blk[len] = 0x80; /* Merkle-Damgård padding sentinel */
+
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        tachyon_vec128_t v;
+        memcpy(v.b, blk + i * VEC_SIZE, VEC_SIZE);
+        d[i] = aesenc_s(v, wk);
+    }
+
+    /* Davies-Meyer save + domain/length injection. */
+    tachyon_vec128_t saves[LANE_STRIDE];
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        saves[i] = acc[i];
+    }
+
+    tachyon_vec128_t meta[LANE_STRIDE] = {
+        to_m128i(domain ^ (uint64_t)len, CHAOS_BASE),
+        to_m128i((uint64_t)len, domain),
+        to_m128i(CHAOS_BASE, (uint64_t)len),
+        to_m128i(domain, CHAOS_BASE)
+    };
+
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        acc[i] = xor_m128i(acc[i], xor_m128i(d[i], meta[i]));
+    }
+
+    for (int r = 0; r < ROUNDS; r++) {
+        tachyon_vec128_t rk = to_m128i(RK_CHAIN[r][0], RK_CHAIN[r][1]);
+
+        for (int i = 0; i < LANE_STRIDE; i++) {
+            acc[i] = aesenc_s(acc[i], add_epi64(d[i], add_epi64(rk, to_m128i(LANE_OFFSETS[i], LANE_OFFSETS[i]))));
+        }
+
+        if (r % 2 == 1) {
+            tachyon_vec128_t t0 = acc[0], t1 = acc[1], t2 = acc[2], t3 = acc[3];
+            d[0] = xor_m128i(d[0], t1);
+            d[1] = xor_m128i(d[1], t2);
+            d[2] = xor_m128i(d[2], t3);
+            d[3] = xor_m128i(d[3], t0);
+        }
+
+        /* Lane rotation: cyclic shift acc[0..3] left by one. */
+        tachyon_vec128_t tmp = acc[0];
+        acc[0] = acc[1];
+        acc[1] = acc[2];
+        acc[2] = acc[3];
+        acc[3] = tmp;
+    }
+
+    for (int i = 0; i < LANE_STRIDE; i++) {
+        acc[i] = xor_m128i(acc[i], saves[i]);
+    }
+}
+
+static void hash_short(const uint8_t *input, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out) {
+    tachyon_vec128_t acc[LANE_STRIDE];
+
+    short_initialize_state(acc, seed, key);
+    short_process_block(acc, input, len, domain);
+    lane_reduction_4to256(acc, out);
+}
+
+// =============================================================================
+// PUBLIC API
+// =============================================================================
+
+void tachyon_portable_oneshot(const uint8_t *data, size_t len, uint64_t domain, uint64_t seed, const uint8_t *key, uint8_t *out) {
+    if (len < REMAINDER_CHUNK_SIZE && seed == 0 && !key) {
+        hash_short(data, len, domain, seed, key, out);
+        return;
+    }
+    struct portable_state_t s;
+    memset(&s, 0, sizeof(s));
+    s.domain = domain;
+    s.seed = seed;
+    if (key) {
+        memcpy(s.key, key, HASH_SIZE);
+        s.has_key = 1;
+    }
+    linear_init(&s);
+    size_t off = 0;
+    uint64_t b_idx = 0;
+    while (len - off >= BLOCK_SIZE) {
+        linear_compress(&s, data + off, b_idx++);
+        off += BLOCK_SIZE;
+    }
+    linear_finalize(&s, data + off, len - off, (uint64_t)len, out);
+}


### PR DESCRIPTION
This PR adds Tachyon, a 256-bit hash function I have been working on. The algorithm was designed primarily for x86-64 with AVX-512+VAES and AES-NI — it does not target ARM or other architectures, though a portable software fallback is included. It uses an 8-lane accumulator state (4096-bit bulk path), a Davies-Meyer feed-forward, and a butterfly network for diffusion. The short-path (<64 bytes) uses a dedicated 4-lane AES-NI path.

The design is cryptographically hardened but has not been formally audited and should be considered highly experimental. It is not intended as a drop-in replacement for cryptographic hash functions. The primary implementation is in Rust. This PR includes the C reference implementation, cross-verified to produce identical output on all three backends.

Verification value: 0xE9BBF229

Performance on Ryzen 7 7700X (AVX-512+VAES) C Implementation:

  Bulk 256 KiB:  ~9700 MiB/sec (~2.2 bytes/cycle)
  Small keys:    ~205 cycles/hash

Full SMHasher results (C + Rust, incl. --extra):
https://github.com/byt3forg3/Tachyon/tree/main/verification/.results